### PR TITLE
2.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,12355 @@
+{
+    "name": "starbase-react",
+    "version": "2.0.0",
+    "lockfileVersion": 1,
+    "requires": true,
+    "dependencies": {
+        "@babel/code-frame": {
+            "version": "7.5.5",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
+            "integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
+            "dev": true,
+            "requires": {
+                "@babel/highlight": "7.5.0"
+            }
+        },
+        "@babel/core": {
+            "version": "7.5.5",
+            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.5.5.tgz",
+            "integrity": "sha512-i4qoSr2KTtce0DmkuuQBV4AuQgGPUcPXMr9L5MyYAtk06z068lQ10a4O009fe5OB/DfNV+h+qqT7ddNV8UnRjg==",
+            "dev": true,
+            "requires": {
+                "@babel/code-frame": "7.5.5",
+                "@babel/generator": "7.5.5",
+                "@babel/helpers": "7.5.5",
+                "@babel/parser": "7.5.5",
+                "@babel/template": "7.4.4",
+                "@babel/traverse": "7.5.5",
+                "@babel/types": "7.5.5",
+                "convert-source-map": "1.6.0",
+                "debug": "4.1.1",
+                "json5": "2.1.0",
+                "lodash": "4.17.15",
+                "resolve": "1.11.1",
+                "semver": "5.7.0",
+                "source-map": "0.5.7"
+            },
+            "dependencies": {
+                "json5": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.0.tgz",
+                    "integrity": "sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==",
+                    "dev": true,
+                    "requires": {
+                        "minimist": "1.2.0"
+                    }
+                },
+                "source-map": {
+                    "version": "0.5.7",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+                    "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+                    "dev": true
+                }
+            }
+        },
+        "@babel/generator": {
+            "version": "7.5.5",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.5.5.tgz",
+            "integrity": "sha512-ETI/4vyTSxTzGnU2c49XHv2zhExkv9JHLTwDAFz85kmcwuShvYG2H08FwgIguQf4JC75CBnXAUM5PqeF4fj0nQ==",
+            "dev": true,
+            "requires": {
+                "@babel/types": "7.5.5",
+                "jsesc": "2.5.2",
+                "lodash": "4.17.15",
+                "source-map": "0.5.7",
+                "trim-right": "1.0.1"
+            },
+            "dependencies": {
+                "source-map": {
+                    "version": "0.5.7",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+                    "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+                    "dev": true
+                }
+            }
+        },
+        "@babel/helper-annotate-as-pure": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.0.0.tgz",
+            "integrity": "sha512-3UYcJUj9kvSLbLbUIfQTqzcy5VX7GRZ/CCDrnOaZorFFM01aXp1+GJwuFGV4NDDoAS+mOUyHcO6UD/RfqOks3Q==",
+            "dev": true,
+            "requires": {
+                "@babel/types": "7.5.5"
+            }
+        },
+        "@babel/helper-builder-binary-assignment-operator-visitor": {
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.1.0.tgz",
+            "integrity": "sha512-qNSR4jrmJ8M1VMM9tibvyRAHXQs2PmaksQF7c1CGJNipfe3D8p+wgNwgso/P2A2r2mdgBWAXljNWR0QRZAMW8w==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-explode-assignable-expression": "7.1.0",
+                "@babel/types": "7.5.5"
+            }
+        },
+        "@babel/helper-builder-react-jsx": {
+            "version": "7.3.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-builder-react-jsx/-/helper-builder-react-jsx-7.3.0.tgz",
+            "integrity": "sha512-MjA9KgwCuPEkQd9ncSXvSyJ5y+j2sICHyrI0M3L+6fnS4wMSNDc1ARXsbTfbb2cXHn17VisSnU/sHFTCxVxSMw==",
+            "dev": true,
+            "requires": {
+                "@babel/types": "7.5.5",
+                "esutils": "2.0.2"
+            }
+        },
+        "@babel/helper-call-delegate": {
+            "version": "7.4.4",
+            "resolved": "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.4.4.tgz",
+            "integrity": "sha512-l79boDFJ8S1c5hvQvG+rc+wHw6IuH7YldmRKsYtpbawsxURu/paVy57FZMomGK22/JckepaikOkY0MoAmdyOlQ==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-hoist-variables": "7.4.4",
+                "@babel/traverse": "7.5.5",
+                "@babel/types": "7.5.5"
+            }
+        },
+        "@babel/helper-define-map": {
+            "version": "7.5.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.5.5.tgz",
+            "integrity": "sha512-fTfxx7i0B5NJqvUOBBGREnrqbTxRh7zinBANpZXAVDlsZxYdclDp467G1sQ8VZYMnAURY3RpBUAgOYT9GfzHBg==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-function-name": "7.1.0",
+                "@babel/types": "7.5.5",
+                "lodash": "4.17.15"
+            }
+        },
+        "@babel/helper-explode-assignable-expression": {
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.1.0.tgz",
+            "integrity": "sha512-NRQpfHrJ1msCHtKjbzs9YcMmJZOg6mQMmGRB+hbamEdG5PNpaSm95275VD92DvJKuyl0s2sFiDmMZ+EnnvufqA==",
+            "dev": true,
+            "requires": {
+                "@babel/traverse": "7.5.5",
+                "@babel/types": "7.5.5"
+            }
+        },
+        "@babel/helper-function-name": {
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
+            "integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-get-function-arity": "7.0.0",
+                "@babel/template": "7.4.4",
+                "@babel/types": "7.5.5"
+            }
+        },
+        "@babel/helper-get-function-arity": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
+            "integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
+            "dev": true,
+            "requires": {
+                "@babel/types": "7.5.5"
+            }
+        },
+        "@babel/helper-hoist-variables": {
+            "version": "7.4.4",
+            "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.4.4.tgz",
+            "integrity": "sha512-VYk2/H/BnYbZDDg39hr3t2kKyifAm1W6zHRfhx8jGjIHpQEBv9dry7oQ2f3+J703TLu69nYdxsovl0XYfcnK4w==",
+            "dev": true,
+            "requires": {
+                "@babel/types": "7.5.5"
+            }
+        },
+        "@babel/helper-member-expression-to-functions": {
+            "version": "7.5.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.5.5.tgz",
+            "integrity": "sha512-5qZ3D1uMclSNqYcXqiHoA0meVdv+xUEex9em2fqMnrk/scphGlGgg66zjMrPJESPwrFJ6sbfFQYUSa0Mz7FabA==",
+            "dev": true,
+            "requires": {
+                "@babel/types": "7.5.5"
+            }
+        },
+        "@babel/helper-module-imports": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.0.0.tgz",
+            "integrity": "sha512-aP/hlLq01DWNEiDg4Jn23i+CXxW/owM4WpDLFUbpjxe4NS3BhLVZQ5i7E0ZrxuQ/vwekIeciyamgB1UIYxxM6A==",
+            "dev": true,
+            "requires": {
+                "@babel/types": "7.5.5"
+            }
+        },
+        "@babel/helper-module-transforms": {
+            "version": "7.5.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.5.5.tgz",
+            "integrity": "sha512-jBeCvETKuJqeiaCdyaheF40aXnnU1+wkSiUs/IQg3tB85up1LyL8x77ClY8qJpuRJUcXQo+ZtdNESmZl4j56Pw==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-module-imports": "7.0.0",
+                "@babel/helper-simple-access": "7.1.0",
+                "@babel/helper-split-export-declaration": "7.4.4",
+                "@babel/template": "7.4.4",
+                "@babel/types": "7.5.5",
+                "lodash": "4.17.15"
+            }
+        },
+        "@babel/helper-optimise-call-expression": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.0.0.tgz",
+            "integrity": "sha512-u8nd9NQePYNQV8iPWu/pLLYBqZBa4ZaY1YWRFMuxrid94wKI1QNt67NEZ7GAe5Kc/0LLScbim05xZFWkAdrj9g==",
+            "dev": true,
+            "requires": {
+                "@babel/types": "7.5.5"
+            }
+        },
+        "@babel/helper-plugin-utils": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0.tgz",
+            "integrity": "sha512-CYAOUCARwExnEixLdB6sDm2dIJ/YgEAKDM1MOeMeZu9Ld/bDgVo8aiWrXwcY7OBh+1Ea2uUcVRcxKk0GJvW7QA==",
+            "dev": true
+        },
+        "@babel/helper-regex": {
+            "version": "7.5.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.5.5.tgz",
+            "integrity": "sha512-CkCYQLkfkiugbRDO8eZn6lRuR8kzZoGXCg3149iTk5se7g6qykSpy3+hELSwquhu+TgHn8nkLiBwHvNX8Hofcw==",
+            "dev": true,
+            "requires": {
+                "lodash": "4.17.15"
+            }
+        },
+        "@babel/helper-remap-async-to-generator": {
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.1.0.tgz",
+            "integrity": "sha512-3fOK0L+Fdlg8S5al8u/hWE6vhufGSn0bN09xm2LXMy//REAF8kDCrYoOBKYmA8m5Nom+sV9LyLCwrFynA8/slg==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-annotate-as-pure": "7.0.0",
+                "@babel/helper-wrap-function": "7.2.0",
+                "@babel/template": "7.4.4",
+                "@babel/traverse": "7.5.5",
+                "@babel/types": "7.5.5"
+            }
+        },
+        "@babel/helper-replace-supers": {
+            "version": "7.5.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.5.5.tgz",
+            "integrity": "sha512-XvRFWrNnlsow2u7jXDuH4jDDctkxbS7gXssrP4q2nUD606ukXHRvydj346wmNg+zAgpFx4MWf4+usfC93bElJg==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-member-expression-to-functions": "7.5.5",
+                "@babel/helper-optimise-call-expression": "7.0.0",
+                "@babel/traverse": "7.5.5",
+                "@babel/types": "7.5.5"
+            }
+        },
+        "@babel/helper-simple-access": {
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.1.0.tgz",
+            "integrity": "sha512-Vk+78hNjRbsiu49zAPALxTb+JUQCz1aolpd8osOF16BGnLtseD21nbHgLPGUwrXEurZgiCOUmvs3ExTu4F5x6w==",
+            "dev": true,
+            "requires": {
+                "@babel/template": "7.4.4",
+                "@babel/types": "7.5.5"
+            }
+        },
+        "@babel/helper-split-export-declaration": {
+            "version": "7.4.4",
+            "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
+            "integrity": "sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==",
+            "dev": true,
+            "requires": {
+                "@babel/types": "7.5.5"
+            }
+        },
+        "@babel/helper-wrap-function": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.2.0.tgz",
+            "integrity": "sha512-o9fP1BZLLSrYlxYEYyl2aS+Flun5gtjTIG8iln+XuEzQTs0PLagAGSXUcqruJwD5fM48jzIEggCKpIfWTcR7pQ==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-function-name": "7.1.0",
+                "@babel/template": "7.4.4",
+                "@babel/traverse": "7.5.5",
+                "@babel/types": "7.5.5"
+            }
+        },
+        "@babel/helpers": {
+            "version": "7.5.5",
+            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.5.5.tgz",
+            "integrity": "sha512-nRq2BUhxZFnfEn/ciJuhklHvFOqjJUD5wpx+1bxUF2axL9C+v4DE/dmp5sT2dKnpOs4orZWzpAZqlCy8QqE/7g==",
+            "dev": true,
+            "requires": {
+                "@babel/template": "7.4.4",
+                "@babel/traverse": "7.5.5",
+                "@babel/types": "7.5.5"
+            }
+        },
+        "@babel/highlight": {
+            "version": "7.5.0",
+            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.5.0.tgz",
+            "integrity": "sha512-7dV4eu9gBxoM0dAnj/BCFDW9LFU0zvTrkq0ugM7pnHEgguOEeOz1so2ZghEdzviYzQEED0r4EAgpsBChKy1TRQ==",
+            "dev": true,
+            "requires": {
+                "chalk": "2.4.2",
+                "esutils": "2.0.2",
+                "js-tokens": "4.0.0"
+            }
+        },
+        "@babel/parser": {
+            "version": "7.5.5",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.5.5.tgz",
+            "integrity": "sha512-E5BN68cqR7dhKan1SfqgPGhQ178bkVKpXTPEXnFJBrEt8/DKRZlybmy+IgYLTeN7tp1R5Ccmbm2rBk17sHYU3g==",
+            "dev": true
+        },
+        "@babel/plugin-proposal-async-generator-functions": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.2.0.tgz",
+            "integrity": "sha512-+Dfo/SCQqrwx48ptLVGLdE39YtWRuKc/Y9I5Fy0P1DDBB9lsAHpjcEJQt+4IifuSOSTLBKJObJqMvaO1pIE8LQ==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "7.0.0",
+                "@babel/helper-remap-async-to-generator": "7.1.0",
+                "@babel/plugin-syntax-async-generators": "7.2.0"
+            }
+        },
+        "@babel/plugin-proposal-dynamic-import": {
+            "version": "7.5.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.5.0.tgz",
+            "integrity": "sha512-x/iMjggsKTFHYC6g11PL7Qy58IK8H5zqfm9e6hu4z1iH2IRyAp9u9dL80zA6R76yFovETFLKz2VJIC2iIPBuFw==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "7.0.0",
+                "@babel/plugin-syntax-dynamic-import": "7.2.0"
+            }
+        },
+        "@babel/plugin-proposal-json-strings": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.2.0.tgz",
+            "integrity": "sha512-MAFV1CA/YVmYwZG0fBQyXhmj0BHCB5egZHCKWIFVv/XCxAeVGIHfos3SwDck4LvCllENIAg7xMKOG5kH0dzyUg==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "7.0.0",
+                "@babel/plugin-syntax-json-strings": "7.2.0"
+            }
+        },
+        "@babel/plugin-proposal-object-rest-spread": {
+            "version": "7.5.5",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.5.5.tgz",
+            "integrity": "sha512-F2DxJJSQ7f64FyTVl5cw/9MWn6naXGdk3Q3UhDbFEEHv+EilCPoeRD3Zh/Utx1CJz4uyKlQ4uH+bJPbEhMV7Zw==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "7.0.0",
+                "@babel/plugin-syntax-object-rest-spread": "7.2.0"
+            }
+        },
+        "@babel/plugin-proposal-optional-catch-binding": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.2.0.tgz",
+            "integrity": "sha512-mgYj3jCcxug6KUcX4OBoOJz3CMrwRfQELPQ5560F70YQUBZB7uac9fqaWamKR1iWUzGiK2t0ygzjTScZnVz75g==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "7.0.0",
+                "@babel/plugin-syntax-optional-catch-binding": "7.2.0"
+            }
+        },
+        "@babel/plugin-proposal-unicode-property-regex": {
+            "version": "7.4.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.4.4.tgz",
+            "integrity": "sha512-j1NwnOqMG9mFUOH58JTFsA/+ZYzQLUZ/drqWUqxCYLGeu2JFZL8YrNC9hBxKmWtAuOCHPcRpgv7fhap09Fb4kA==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "7.0.0",
+                "@babel/helper-regex": "7.5.5",
+                "regexpu-core": "4.5.4"
+            }
+        },
+        "@babel/plugin-syntax-async-generators": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.2.0.tgz",
+            "integrity": "sha512-1ZrIRBv2t0GSlcwVoQ6VgSLpLgiN/FVQUzt9znxo7v2Ov4jJrs8RY8tv0wvDmFN3qIdMKWrmMMW6yZ0G19MfGg==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "7.0.0"
+            }
+        },
+        "@babel/plugin-syntax-dynamic-import": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.2.0.tgz",
+            "integrity": "sha512-mVxuJ0YroI/h/tbFTPGZR8cv6ai+STMKNBq0f8hFxsxWjl94qqhsb+wXbpNMDPU3cfR1TIsVFzU3nXyZMqyK4w==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "7.0.0"
+            }
+        },
+        "@babel/plugin-syntax-json-strings": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.2.0.tgz",
+            "integrity": "sha512-5UGYnMSLRE1dqqZwug+1LISpA403HzlSfsg6P9VXU6TBjcSHeNlw4DxDx7LgpF+iKZoOG/+uzqoRHTdcUpiZNg==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "7.0.0"
+            }
+        },
+        "@babel/plugin-syntax-jsx": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.2.0.tgz",
+            "integrity": "sha512-VyN4QANJkRW6lDBmENzRszvZf3/4AXaj9YR7GwrWeeN9tEBPuXbmDYVU9bYBN0D70zCWVwUy0HWq2553VCb6Hw==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "7.0.0"
+            }
+        },
+        "@babel/plugin-syntax-object-rest-spread": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.2.0.tgz",
+            "integrity": "sha512-t0JKGgqk2We+9may3t0xDdmneaXmyxq0xieYcKHxIsrJO64n1OiMWNUtc5gQK1PA0NpdCRrtZp4z+IUaKugrSA==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "7.0.0"
+            }
+        },
+        "@babel/plugin-syntax-optional-catch-binding": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.2.0.tgz",
+            "integrity": "sha512-bDe4xKNhb0LI7IvZHiA13kff0KEfaGX/Hv4lMA9+7TEc63hMNvfKo6ZFpXhKuEp+II/q35Gc4NoMeDZyaUbj9w==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "7.0.0"
+            }
+        },
+        "@babel/plugin-transform-arrow-functions": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.2.0.tgz",
+            "integrity": "sha512-ER77Cax1+8/8jCB9fo4Ud161OZzWN5qawi4GusDuRLcDbDG+bIGYY20zb2dfAFdTRGzrfq2xZPvF0R64EHnimg==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "7.0.0"
+            }
+        },
+        "@babel/plugin-transform-async-to-generator": {
+            "version": "7.5.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.5.0.tgz",
+            "integrity": "sha512-mqvkzwIGkq0bEF1zLRRiTdjfomZJDV33AH3oQzHVGkI2VzEmXLpKKOBvEVaFZBJdN0XTyH38s9j/Kiqr68dggg==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-module-imports": "7.0.0",
+                "@babel/helper-plugin-utils": "7.0.0",
+                "@babel/helper-remap-async-to-generator": "7.1.0"
+            }
+        },
+        "@babel/plugin-transform-block-scoped-functions": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.2.0.tgz",
+            "integrity": "sha512-ntQPR6q1/NKuphly49+QiQiTN0O63uOwjdD6dhIjSWBI5xlrbUFh720TIpzBhpnrLfv2tNH/BXvLIab1+BAI0w==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "7.0.0"
+            }
+        },
+        "@babel/plugin-transform-block-scoping": {
+            "version": "7.5.5",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.5.5.tgz",
+            "integrity": "sha512-82A3CLRRdYubkG85lKwhZB0WZoHxLGsJdux/cOVaJCJpvYFl1LVzAIFyRsa7CvXqW8rBM4Zf3Bfn8PHt5DP0Sg==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "7.0.0",
+                "lodash": "4.17.15"
+            }
+        },
+        "@babel/plugin-transform-classes": {
+            "version": "7.5.5",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.5.5.tgz",
+            "integrity": "sha512-U2htCNK/6e9K7jGyJ++1p5XRU+LJjrwtoiVn9SzRlDT2KubcZ11OOwy3s24TjHxPgxNwonCYP7U2K51uVYCMDg==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-annotate-as-pure": "7.0.0",
+                "@babel/helper-define-map": "7.5.5",
+                "@babel/helper-function-name": "7.1.0",
+                "@babel/helper-optimise-call-expression": "7.0.0",
+                "@babel/helper-plugin-utils": "7.0.0",
+                "@babel/helper-replace-supers": "7.5.5",
+                "@babel/helper-split-export-declaration": "7.4.4",
+                "globals": "11.12.0"
+            }
+        },
+        "@babel/plugin-transform-computed-properties": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.2.0.tgz",
+            "integrity": "sha512-kP/drqTxY6Xt3NNpKiMomfgkNn4o7+vKxK2DDKcBG9sHj51vHqMBGy8wbDS/J4lMxnqs153/T3+DmCEAkC5cpA==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "7.0.0"
+            }
+        },
+        "@babel/plugin-transform-destructuring": {
+            "version": "7.5.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.5.0.tgz",
+            "integrity": "sha512-YbYgbd3TryYYLGyC7ZR+Tq8H/+bCmwoaxHfJHupom5ECstzbRLTch6gOQbhEY9Z4hiCNHEURgq06ykFv9JZ/QQ==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "7.0.0"
+            }
+        },
+        "@babel/plugin-transform-dotall-regex": {
+            "version": "7.4.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.4.4.tgz",
+            "integrity": "sha512-P05YEhRc2h53lZDjRPk/OektxCVevFzZs2Gfjd545Wde3k+yFDbXORgl2e0xpbq8mLcKJ7Idss4fAg0zORN/zg==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "7.0.0",
+                "@babel/helper-regex": "7.5.5",
+                "regexpu-core": "4.5.4"
+            }
+        },
+        "@babel/plugin-transform-duplicate-keys": {
+            "version": "7.5.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.5.0.tgz",
+            "integrity": "sha512-igcziksHizyQPlX9gfSjHkE2wmoCH3evvD2qR5w29/Dk0SMKE/eOI7f1HhBdNhR/zxJDqrgpoDTq5YSLH/XMsQ==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "7.0.0"
+            }
+        },
+        "@babel/plugin-transform-exponentiation-operator": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.2.0.tgz",
+            "integrity": "sha512-umh4hR6N7mu4Elq9GG8TOu9M0bakvlsREEC+ialrQN6ABS4oDQ69qJv1VtR3uxlKMCQMCvzk7vr17RHKcjx68A==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-builder-binary-assignment-operator-visitor": "7.1.0",
+                "@babel/helper-plugin-utils": "7.0.0"
+            }
+        },
+        "@babel/plugin-transform-for-of": {
+            "version": "7.4.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.4.4.tgz",
+            "integrity": "sha512-9T/5Dlr14Z9TIEXLXkt8T1DU7F24cbhwhMNUziN3hB1AXoZcdzPcTiKGRn/6iOymDqtTKWnr/BtRKN9JwbKtdQ==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "7.0.0"
+            }
+        },
+        "@babel/plugin-transform-function-name": {
+            "version": "7.4.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.4.4.tgz",
+            "integrity": "sha512-iU9pv7U+2jC9ANQkKeNF6DrPy4GBa4NWQtl6dHB4Pb3izX2JOEvDTFarlNsBj/63ZEzNNIAMs3Qw4fNCcSOXJA==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-function-name": "7.1.0",
+                "@babel/helper-plugin-utils": "7.0.0"
+            }
+        },
+        "@babel/plugin-transform-literals": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.2.0.tgz",
+            "integrity": "sha512-2ThDhm4lI4oV7fVQ6pNNK+sx+c/GM5/SaML0w/r4ZB7sAneD/piDJtwdKlNckXeyGK7wlwg2E2w33C/Hh+VFCg==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "7.0.0"
+            }
+        },
+        "@babel/plugin-transform-member-expression-literals": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.2.0.tgz",
+            "integrity": "sha512-HiU3zKkSU6scTidmnFJ0bMX8hz5ixC93b4MHMiYebmk2lUVNGOboPsqQvx5LzooihijUoLR/v7Nc1rbBtnc7FA==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "7.0.0"
+            }
+        },
+        "@babel/plugin-transform-modules-amd": {
+            "version": "7.5.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.5.0.tgz",
+            "integrity": "sha512-n20UsQMKnWrltocZZm24cRURxQnWIvsABPJlw/fvoy9c6AgHZzoelAIzajDHAQrDpuKFFPPcFGd7ChsYuIUMpg==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-module-transforms": "7.5.5",
+                "@babel/helper-plugin-utils": "7.0.0",
+                "babel-plugin-dynamic-import-node": "2.3.0"
+            }
+        },
+        "@babel/plugin-transform-modules-commonjs": {
+            "version": "7.5.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.5.0.tgz",
+            "integrity": "sha512-xmHq0B+ytyrWJvQTc5OWAC4ii6Dhr0s22STOoydokG51JjWhyYo5mRPXoi+ZmtHQhZZwuXNN+GG5jy5UZZJxIQ==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-module-transforms": "7.5.5",
+                "@babel/helper-plugin-utils": "7.0.0",
+                "@babel/helper-simple-access": "7.1.0",
+                "babel-plugin-dynamic-import-node": "2.3.0"
+            }
+        },
+        "@babel/plugin-transform-modules-systemjs": {
+            "version": "7.5.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.5.0.tgz",
+            "integrity": "sha512-Q2m56tyoQWmuNGxEtUyeEkm6qJYFqs4c+XyXH5RAuYxObRNz9Zgj/1g2GMnjYp2EUyEy7YTrxliGCXzecl/vJg==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-hoist-variables": "7.4.4",
+                "@babel/helper-plugin-utils": "7.0.0",
+                "babel-plugin-dynamic-import-node": "2.3.0"
+            }
+        },
+        "@babel/plugin-transform-modules-umd": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.2.0.tgz",
+            "integrity": "sha512-BV3bw6MyUH1iIsGhXlOK6sXhmSarZjtJ/vMiD9dNmpY8QXFFQTj+6v92pcfy1iqa8DeAfJFwoxcrS/TUZda6sw==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-module-transforms": "7.5.5",
+                "@babel/helper-plugin-utils": "7.0.0"
+            }
+        },
+        "@babel/plugin-transform-named-capturing-groups-regex": {
+            "version": "7.4.5",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.4.5.tgz",
+            "integrity": "sha512-z7+2IsWafTBbjNsOxU/Iv5CvTJlr5w4+HGu1HovKYTtgJ362f7kBcQglkfmlspKKZ3bgrbSGvLfNx++ZJgCWsg==",
+            "dev": true,
+            "requires": {
+                "regexp-tree": "0.1.11"
+            }
+        },
+        "@babel/plugin-transform-new-target": {
+            "version": "7.4.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.4.4.tgz",
+            "integrity": "sha512-r1z3T2DNGQwwe2vPGZMBNjioT2scgWzK9BCnDEh+46z8EEwXBq24uRzd65I7pjtugzPSj921aM15RpESgzsSuA==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "7.0.0"
+            }
+        },
+        "@babel/plugin-transform-object-super": {
+            "version": "7.5.5",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.5.5.tgz",
+            "integrity": "sha512-un1zJQAhSosGFBduPgN/YFNvWVpRuHKU7IHBglLoLZsGmruJPOo6pbInneflUdmq7YvSVqhpPs5zdBvLnteltQ==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "7.0.0",
+                "@babel/helper-replace-supers": "7.5.5"
+            }
+        },
+        "@babel/plugin-transform-parameters": {
+            "version": "7.4.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.4.4.tgz",
+            "integrity": "sha512-oMh5DUO1V63nZcu/ZVLQFqiihBGo4OpxJxR1otF50GMeCLiRx5nUdtokd+u9SuVJrvvuIh9OosRFPP4pIPnwmw==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-call-delegate": "7.4.4",
+                "@babel/helper-get-function-arity": "7.0.0",
+                "@babel/helper-plugin-utils": "7.0.0"
+            }
+        },
+        "@babel/plugin-transform-property-literals": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.2.0.tgz",
+            "integrity": "sha512-9q7Dbk4RhgcLp8ebduOpCbtjh7C0itoLYHXd9ueASKAG/is5PQtMR5VJGka9NKqGhYEGn5ITahd4h9QeBMylWQ==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "7.0.0"
+            }
+        },
+        "@babel/plugin-transform-react-display-name": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.2.0.tgz",
+            "integrity": "sha512-Htf/tPa5haZvRMiNSQSFifK12gtr/8vwfr+A9y69uF0QcU77AVu4K7MiHEkTxF7lQoHOL0F9ErqgfNEAKgXj7A==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "7.0.0"
+            }
+        },
+        "@babel/plugin-transform-react-jsx": {
+            "version": "7.3.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.3.0.tgz",
+            "integrity": "sha512-a/+aRb7R06WcKvQLOu4/TpjKOdvVEKRLWFpKcNuHhiREPgGRB4TQJxq07+EZLS8LFVYpfq1a5lDUnuMdcCpBKg==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-builder-react-jsx": "7.3.0",
+                "@babel/helper-plugin-utils": "7.0.0",
+                "@babel/plugin-syntax-jsx": "7.2.0"
+            }
+        },
+        "@babel/plugin-transform-react-jsx-self": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.2.0.tgz",
+            "integrity": "sha512-v6S5L/myicZEy+jr6ielB0OR8h+EH/1QFx/YJ7c7Ua+7lqsjj/vW6fD5FR9hB/6y7mGbfT4vAURn3xqBxsUcdg==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "7.0.0",
+                "@babel/plugin-syntax-jsx": "7.2.0"
+            }
+        },
+        "@babel/plugin-transform-react-jsx-source": {
+            "version": "7.5.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.5.0.tgz",
+            "integrity": "sha512-58Q+Jsy4IDCZx7kqEZuSDdam/1oW8OdDX8f+Loo6xyxdfg1yF0GE2XNJQSTZCaMol93+FBzpWiPEwtbMloAcPg==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "7.0.0",
+                "@babel/plugin-syntax-jsx": "7.2.0"
+            }
+        },
+        "@babel/plugin-transform-regenerator": {
+            "version": "7.4.5",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.4.5.tgz",
+            "integrity": "sha512-gBKRh5qAaCWntnd09S8QC7r3auLCqq5DI6O0DlfoyDjslSBVqBibrMdsqO+Uhmx3+BlOmE/Kw1HFxmGbv0N9dA==",
+            "dev": true,
+            "requires": {
+                "regenerator-transform": "0.14.1"
+            }
+        },
+        "@babel/plugin-transform-reserved-words": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.2.0.tgz",
+            "integrity": "sha512-fz43fqW8E1tAB3DKF19/vxbpib1fuyCwSPE418ge5ZxILnBhWyhtPgz8eh1RCGGJlwvksHkyxMxh0eenFi+kFw==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "7.0.0"
+            }
+        },
+        "@babel/plugin-transform-shorthand-properties": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.2.0.tgz",
+            "integrity": "sha512-QP4eUM83ha9zmYtpbnyjTLAGKQritA5XW/iG9cjtuOI8s1RuL/3V6a3DeSHfKutJQ+ayUfeZJPcnCYEQzaPQqg==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "7.0.0"
+            }
+        },
+        "@babel/plugin-transform-spread": {
+            "version": "7.2.2",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.2.2.tgz",
+            "integrity": "sha512-KWfky/58vubwtS0hLqEnrWJjsMGaOeSBn90Ezn5Jeg9Z8KKHmELbP1yGylMlm5N6TPKeY9A2+UaSYLdxahg01w==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "7.0.0"
+            }
+        },
+        "@babel/plugin-transform-sticky-regex": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.2.0.tgz",
+            "integrity": "sha512-KKYCoGaRAf+ckH8gEL3JHUaFVyNHKe3ASNsZ+AlktgHevvxGigoIttrEJb8iKN03Q7Eazlv1s6cx2B2cQ3Jabw==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "7.0.0",
+                "@babel/helper-regex": "7.5.5"
+            }
+        },
+        "@babel/plugin-transform-template-literals": {
+            "version": "7.4.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.4.4.tgz",
+            "integrity": "sha512-mQrEC4TWkhLN0z8ygIvEL9ZEToPhG5K7KDW3pzGqOfIGZ28Jb0POUkeWcoz8HnHvhFy6dwAT1j8OzqN8s804+g==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-annotate-as-pure": "7.0.0",
+                "@babel/helper-plugin-utils": "7.0.0"
+            }
+        },
+        "@babel/plugin-transform-typeof-symbol": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.2.0.tgz",
+            "integrity": "sha512-2LNhETWYxiYysBtrBTqL8+La0jIoQQnIScUJc74OYvUGRmkskNY4EzLCnjHBzdmb38wqtTaixpo1NctEcvMDZw==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "7.0.0"
+            }
+        },
+        "@babel/plugin-transform-unicode-regex": {
+            "version": "7.4.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.4.4.tgz",
+            "integrity": "sha512-il+/XdNw01i93+M9J9u4T7/e/Ue/vWfNZE4IRUQjplu2Mqb/AFTDimkw2tdEdSH50wuQXZAbXSql0UphQke+vA==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "7.0.0",
+                "@babel/helper-regex": "7.5.5",
+                "regexpu-core": "4.5.4"
+            }
+        },
+        "@babel/preset-env": {
+            "version": "7.5.5",
+            "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.5.5.tgz",
+            "integrity": "sha512-GMZQka/+INwsMz1A5UEql8tG015h5j/qjptpKY2gJ7giy8ohzU710YciJB5rcKsWGWHiW3RUnHib0E5/m3Tp3A==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-module-imports": "7.0.0",
+                "@babel/helper-plugin-utils": "7.0.0",
+                "@babel/plugin-proposal-async-generator-functions": "7.2.0",
+                "@babel/plugin-proposal-dynamic-import": "7.5.0",
+                "@babel/plugin-proposal-json-strings": "7.2.0",
+                "@babel/plugin-proposal-object-rest-spread": "7.5.5",
+                "@babel/plugin-proposal-optional-catch-binding": "7.2.0",
+                "@babel/plugin-proposal-unicode-property-regex": "7.4.4",
+                "@babel/plugin-syntax-async-generators": "7.2.0",
+                "@babel/plugin-syntax-dynamic-import": "7.2.0",
+                "@babel/plugin-syntax-json-strings": "7.2.0",
+                "@babel/plugin-syntax-object-rest-spread": "7.2.0",
+                "@babel/plugin-syntax-optional-catch-binding": "7.2.0",
+                "@babel/plugin-transform-arrow-functions": "7.2.0",
+                "@babel/plugin-transform-async-to-generator": "7.5.0",
+                "@babel/plugin-transform-block-scoped-functions": "7.2.0",
+                "@babel/plugin-transform-block-scoping": "7.5.5",
+                "@babel/plugin-transform-classes": "7.5.5",
+                "@babel/plugin-transform-computed-properties": "7.2.0",
+                "@babel/plugin-transform-destructuring": "7.5.0",
+                "@babel/plugin-transform-dotall-regex": "7.4.4",
+                "@babel/plugin-transform-duplicate-keys": "7.5.0",
+                "@babel/plugin-transform-exponentiation-operator": "7.2.0",
+                "@babel/plugin-transform-for-of": "7.4.4",
+                "@babel/plugin-transform-function-name": "7.4.4",
+                "@babel/plugin-transform-literals": "7.2.0",
+                "@babel/plugin-transform-member-expression-literals": "7.2.0",
+                "@babel/plugin-transform-modules-amd": "7.5.0",
+                "@babel/plugin-transform-modules-commonjs": "7.5.0",
+                "@babel/plugin-transform-modules-systemjs": "7.5.0",
+                "@babel/plugin-transform-modules-umd": "7.2.0",
+                "@babel/plugin-transform-named-capturing-groups-regex": "7.4.5",
+                "@babel/plugin-transform-new-target": "7.4.4",
+                "@babel/plugin-transform-object-super": "7.5.5",
+                "@babel/plugin-transform-parameters": "7.4.4",
+                "@babel/plugin-transform-property-literals": "7.2.0",
+                "@babel/plugin-transform-regenerator": "7.4.5",
+                "@babel/plugin-transform-reserved-words": "7.2.0",
+                "@babel/plugin-transform-shorthand-properties": "7.2.0",
+                "@babel/plugin-transform-spread": "7.2.2",
+                "@babel/plugin-transform-sticky-regex": "7.2.0",
+                "@babel/plugin-transform-template-literals": "7.4.4",
+                "@babel/plugin-transform-typeof-symbol": "7.2.0",
+                "@babel/plugin-transform-unicode-regex": "7.4.4",
+                "@babel/types": "7.5.5",
+                "browserslist": "4.6.6",
+                "core-js-compat": "3.1.4",
+                "invariant": "2.2.4",
+                "js-levenshtein": "1.1.6",
+                "semver": "5.7.0"
+            }
+        },
+        "@babel/preset-react": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.0.0.tgz",
+            "integrity": "sha512-oayxyPS4Zj+hF6Et11BwuBkmpgT/zMxyuZgFrMeZID6Hdh3dGlk4sHCAhdBCpuCKW2ppBfl2uCCetlrUIJRY3w==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "7.0.0",
+                "@babel/plugin-transform-react-display-name": "7.2.0",
+                "@babel/plugin-transform-react-jsx": "7.3.0",
+                "@babel/plugin-transform-react-jsx-self": "7.2.0",
+                "@babel/plugin-transform-react-jsx-source": "7.5.0"
+            }
+        },
+        "@babel/runtime": {
+            "version": "7.5.5",
+            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.5.5.tgz",
+            "integrity": "sha512-28QvEGyQyNkB0/m2B4FU7IEZGK2NUrcMtT6BZEFALTguLk+AUT6ofsHtPk5QyjAdUkpMJ+/Em+quwz4HOt30AQ==",
+            "requires": {
+                "regenerator-runtime": "0.13.3"
+            }
+        },
+        "@babel/template": {
+            "version": "7.4.4",
+            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.4.tgz",
+            "integrity": "sha512-CiGzLN9KgAvgZsnivND7rkA+AeJ9JB0ciPOD4U59GKbQP2iQl+olF1l76kJOupqidozfZ32ghwBEJDhnk9MEcw==",
+            "dev": true,
+            "requires": {
+                "@babel/code-frame": "7.5.5",
+                "@babel/parser": "7.5.5",
+                "@babel/types": "7.5.5"
+            }
+        },
+        "@babel/traverse": {
+            "version": "7.5.5",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.5.5.tgz",
+            "integrity": "sha512-MqB0782whsfffYfSjH4TM+LMjrJnhCNEDMDIjeTpl+ASaUvxcjoiVCo/sM1GhS1pHOXYfWVCYneLjMckuUxDaQ==",
+            "dev": true,
+            "requires": {
+                "@babel/code-frame": "7.5.5",
+                "@babel/generator": "7.5.5",
+                "@babel/helper-function-name": "7.1.0",
+                "@babel/helper-split-export-declaration": "7.4.4",
+                "@babel/parser": "7.5.5",
+                "@babel/types": "7.5.5",
+                "debug": "4.1.1",
+                "globals": "11.12.0",
+                "lodash": "4.17.15"
+            }
+        },
+        "@babel/types": {
+            "version": "7.5.5",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.5.5.tgz",
+            "integrity": "sha512-s63F9nJioLqOlW3UkyMd+BYhXt44YuaFm/VV0VwuteqjYwRrObkU7ra9pY4wAJR3oXi8hJrMcrcJdO/HH33vtw==",
+            "dev": true,
+            "requires": {
+                "esutils": "2.0.2",
+                "lodash": "4.17.15",
+                "to-fast-properties": "2.0.0"
+            }
+        },
+        "@csstools/convert-colors": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/@csstools/convert-colors/-/convert-colors-1.4.0.tgz",
+            "integrity": "sha512-5a6wqoJV/xEdbRNKVo6I4hO3VjyDq//8q2f9I6PBAvMesJHFauXDorcNCsr9RzvsZnaWi5NYCcfyqP1QeFHFbw==",
+            "dev": true
+        },
+        "@mrmlnc/readdir-enhanced": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
+            "integrity": "sha512-bPHp6Ji8b41szTOcaP63VlnbbO5Ny6dwAATtY6JTjh5N2OLrb5Qk/Th5cRkRQhkWCt+EJsYrNB0MiL+Gpn6e3g==",
+            "dev": true,
+            "requires": {
+                "call-me-maybe": "1.0.1",
+                "glob-to-regexp": "0.3.0"
+            }
+        },
+        "@nodelib/fs.stat": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz",
+            "integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==",
+            "dev": true
+        },
+        "@types/anymatch": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/@types/anymatch/-/anymatch-1.3.1.tgz",
+            "integrity": "sha512-/+CRPXpBDpo2RK9C68N3b2cOvO0Cf5B9aPijHsoDQTHivnGSObdOF2BRQOYjojWTDy6nQvMjmqRXIxH55VjxxA==",
+            "dev": true
+        },
+        "@types/events": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
+            "integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==",
+            "dev": true
+        },
+        "@types/glob": {
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.1.tgz",
+            "integrity": "sha512-1Bh06cbWJUHMC97acuD6UMG29nMt0Aqz1vF3guLfG+kHHJhy3AyohZFFxYk2f7Q1SQIrNwvncxAE0N/9s70F2w==",
+            "dev": true,
+            "requires": {
+                "@types/events": "3.0.0",
+                "@types/minimatch": "3.0.3",
+                "@types/node": "12.6.8"
+            }
+        },
+        "@types/minimatch": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
+            "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
+            "dev": true
+        },
+        "@types/node": {
+            "version": "12.6.8",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-12.6.8.tgz",
+            "integrity": "sha512-aX+gFgA5GHcDi89KG5keey2zf0WfZk/HAQotEamsK2kbey+8yGKcson0hbK8E+v0NArlCJQCqMP161YhV6ZXLg==",
+            "dev": true
+        },
+        "@types/q": {
+            "version": "1.5.2",
+            "resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.2.tgz",
+            "integrity": "sha512-ce5d3q03Ex0sy4R14722Rmt6MT07Ua+k4FwDfdcToYJcMKNtRVQvJ6JCAPdAmAnbRb6CsX6aYb9m96NGod9uTw==",
+            "dev": true
+        },
+        "@types/tapable": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/@types/tapable/-/tapable-1.0.4.tgz",
+            "integrity": "sha512-78AdXtlhpCHT0K3EytMpn4JNxaf5tbqbLcbIRoQIHzpTIyjpxLQKRoxU55ujBXAtg3Nl2h/XWvfDa9dsMOd0pQ==",
+            "dev": true
+        },
+        "@types/uglify-js": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/@types/uglify-js/-/uglify-js-3.0.4.tgz",
+            "integrity": "sha512-SudIN9TRJ+v8g5pTG8RRCqfqTMNqgWCKKd3vtynhGzkIIjxaicNAMuY5TRadJ6tzDu3Dotf3ngaMILtmOdmWEQ==",
+            "dev": true,
+            "requires": {
+                "source-map": "0.6.1"
+            },
+            "dependencies": {
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
+                }
+            }
+        },
+        "@types/unist": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.3.tgz",
+            "integrity": "sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ==",
+            "dev": true
+        },
+        "@types/vfile": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/@types/vfile/-/vfile-3.0.2.tgz",
+            "integrity": "sha512-b3nLFGaGkJ9rzOcuXRfHkZMdjsawuDD0ENL9fzTophtBg8FJHSGbH7daXkEpcwy3v7Xol3pAvsmlYyFhR4pqJw==",
+            "dev": true,
+            "requires": {
+                "@types/node": "12.6.8",
+                "@types/unist": "2.0.3",
+                "@types/vfile-message": "1.0.1"
+            }
+        },
+        "@types/vfile-message": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@types/vfile-message/-/vfile-message-1.0.1.tgz",
+            "integrity": "sha512-mlGER3Aqmq7bqR1tTTIVHq8KSAFFRyGbrxuM8C/H82g6k7r2fS+IMEkIu3D7JHzG10NvPdR8DNx0jr0pwpp4dA==",
+            "dev": true,
+            "requires": {
+                "@types/node": "12.6.8",
+                "@types/unist": "2.0.3"
+            }
+        },
+        "@types/webpack": {
+            "version": "4.32.0",
+            "resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-4.32.0.tgz",
+            "integrity": "sha512-kpz5wHDyG/WEpzX9gcwFp/w0oSsq0n/rmFdJelk/QBMHmNIOZdiTDInV0Lj8itGKBahQrBgJGJRss/6UHgLuKg==",
+            "dev": true,
+            "requires": {
+                "@types/anymatch": "1.3.1",
+                "@types/node": "12.6.8",
+                "@types/tapable": "1.0.4",
+                "@types/uglify-js": "3.0.4",
+                "source-map": "0.6.1"
+            },
+            "dependencies": {
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
+                }
+            }
+        },
+        "@webassemblyjs/ast": {
+            "version": "1.8.5",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.8.5.tgz",
+            "integrity": "sha512-aJMfngIZ65+t71C3y2nBBg5FFG0Okt9m0XEgWZ7Ywgn1oMAT8cNwx00Uv1cQyHtidq0Xn94R4TAywO+LCQ+ZAQ==",
+            "dev": true,
+            "requires": {
+                "@webassemblyjs/helper-module-context": "1.8.5",
+                "@webassemblyjs/helper-wasm-bytecode": "1.8.5",
+                "@webassemblyjs/wast-parser": "1.8.5"
+            }
+        },
+        "@webassemblyjs/floating-point-hex-parser": {
+            "version": "1.8.5",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.8.5.tgz",
+            "integrity": "sha512-9p+79WHru1oqBh9ewP9zW95E3XAo+90oth7S5Re3eQnECGq59ly1Ri5tsIipKGpiStHsUYmY3zMLqtk3gTcOtQ==",
+            "dev": true
+        },
+        "@webassemblyjs/helper-api-error": {
+            "version": "1.8.5",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.8.5.tgz",
+            "integrity": "sha512-Za/tnzsvnqdaSPOUXHyKJ2XI7PDX64kWtURyGiJJZKVEdFOsdKUCPTNEVFZq3zJ2R0G5wc2PZ5gvdTRFgm81zA==",
+            "dev": true
+        },
+        "@webassemblyjs/helper-buffer": {
+            "version": "1.8.5",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.8.5.tgz",
+            "integrity": "sha512-Ri2R8nOS0U6G49Q86goFIPNgjyl6+oE1abW1pS84BuhP1Qcr5JqMwRFT3Ah3ADDDYGEgGs1iyb1DGX+kAi/c/Q==",
+            "dev": true
+        },
+        "@webassemblyjs/helper-code-frame": {
+            "version": "1.8.5",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-code-frame/-/helper-code-frame-1.8.5.tgz",
+            "integrity": "sha512-VQAadSubZIhNpH46IR3yWO4kZZjMxN1opDrzePLdVKAZ+DFjkGD/rf4v1jap744uPVU6yjL/smZbRIIJTOUnKQ==",
+            "dev": true,
+            "requires": {
+                "@webassemblyjs/wast-printer": "1.8.5"
+            }
+        },
+        "@webassemblyjs/helper-fsm": {
+            "version": "1.8.5",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-fsm/-/helper-fsm-1.8.5.tgz",
+            "integrity": "sha512-kRuX/saORcg8se/ft6Q2UbRpZwP4y7YrWsLXPbbmtepKr22i8Z4O3V5QE9DbZK908dh5Xya4Un57SDIKwB9eow==",
+            "dev": true
+        },
+        "@webassemblyjs/helper-module-context": {
+            "version": "1.8.5",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-module-context/-/helper-module-context-1.8.5.tgz",
+            "integrity": "sha512-/O1B236mN7UNEU4t9X7Pj38i4VoU8CcMHyy3l2cV/kIF4U5KoHXDVqcDuOs1ltkac90IM4vZdHc52t1x8Yfs3g==",
+            "dev": true,
+            "requires": {
+                "@webassemblyjs/ast": "1.8.5",
+                "mamacro": "0.0.3"
+            }
+        },
+        "@webassemblyjs/helper-wasm-bytecode": {
+            "version": "1.8.5",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.8.5.tgz",
+            "integrity": "sha512-Cu4YMYG3Ddl72CbmpjU/wbP6SACcOPVbHN1dI4VJNJVgFwaKf1ppeFJrwydOG3NDHxVGuCfPlLZNyEdIYlQ6QQ==",
+            "dev": true
+        },
+        "@webassemblyjs/helper-wasm-section": {
+            "version": "1.8.5",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.8.5.tgz",
+            "integrity": "sha512-VV083zwR+VTrIWWtgIUpqfvVdK4ff38loRmrdDBgBT8ADXYsEZ5mPQ4Nde90N3UYatHdYoDIFb7oHzMncI02tA==",
+            "dev": true,
+            "requires": {
+                "@webassemblyjs/ast": "1.8.5",
+                "@webassemblyjs/helper-buffer": "1.8.5",
+                "@webassemblyjs/helper-wasm-bytecode": "1.8.5",
+                "@webassemblyjs/wasm-gen": "1.8.5"
+            }
+        },
+        "@webassemblyjs/ieee754": {
+            "version": "1.8.5",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.8.5.tgz",
+            "integrity": "sha512-aaCvQYrvKbY/n6wKHb/ylAJr27GglahUO89CcGXMItrOBqRarUMxWLJgxm9PJNuKULwN5n1csT9bYoMeZOGF3g==",
+            "dev": true,
+            "requires": {
+                "@xtuc/ieee754": "1.2.0"
+            }
+        },
+        "@webassemblyjs/leb128": {
+            "version": "1.8.5",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.8.5.tgz",
+            "integrity": "sha512-plYUuUwleLIziknvlP8VpTgO4kqNaH57Y3JnNa6DLpu/sGcP6hbVdfdX5aHAV716pQBKrfuU26BJK29qY37J7A==",
+            "dev": true,
+            "requires": {
+                "@xtuc/long": "4.2.2"
+            }
+        },
+        "@webassemblyjs/utf8": {
+            "version": "1.8.5",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.8.5.tgz",
+            "integrity": "sha512-U7zgftmQriw37tfD934UNInokz6yTmn29inT2cAetAsaU9YeVCveWEwhKL1Mg4yS7q//NGdzy79nlXh3bT8Kjw==",
+            "dev": true
+        },
+        "@webassemblyjs/wasm-edit": {
+            "version": "1.8.5",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.8.5.tgz",
+            "integrity": "sha512-A41EMy8MWw5yvqj7MQzkDjU29K7UJq1VrX2vWLzfpRHt3ISftOXqrtojn7nlPsZ9Ijhp5NwuODuycSvfAO/26Q==",
+            "dev": true,
+            "requires": {
+                "@webassemblyjs/ast": "1.8.5",
+                "@webassemblyjs/helper-buffer": "1.8.5",
+                "@webassemblyjs/helper-wasm-bytecode": "1.8.5",
+                "@webassemblyjs/helper-wasm-section": "1.8.5",
+                "@webassemblyjs/wasm-gen": "1.8.5",
+                "@webassemblyjs/wasm-opt": "1.8.5",
+                "@webassemblyjs/wasm-parser": "1.8.5",
+                "@webassemblyjs/wast-printer": "1.8.5"
+            }
+        },
+        "@webassemblyjs/wasm-gen": {
+            "version": "1.8.5",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.8.5.tgz",
+            "integrity": "sha512-BCZBT0LURC0CXDzj5FXSc2FPTsxwp3nWcqXQdOZE4U7h7i8FqtFK5Egia6f9raQLpEKT1VL7zr4r3+QX6zArWg==",
+            "dev": true,
+            "requires": {
+                "@webassemblyjs/ast": "1.8.5",
+                "@webassemblyjs/helper-wasm-bytecode": "1.8.5",
+                "@webassemblyjs/ieee754": "1.8.5",
+                "@webassemblyjs/leb128": "1.8.5",
+                "@webassemblyjs/utf8": "1.8.5"
+            }
+        },
+        "@webassemblyjs/wasm-opt": {
+            "version": "1.8.5",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.8.5.tgz",
+            "integrity": "sha512-HKo2mO/Uh9A6ojzu7cjslGaHaUU14LdLbGEKqTR7PBKwT6LdPtLLh9fPY33rmr5wcOMrsWDbbdCHq4hQUdd37Q==",
+            "dev": true,
+            "requires": {
+                "@webassemblyjs/ast": "1.8.5",
+                "@webassemblyjs/helper-buffer": "1.8.5",
+                "@webassemblyjs/wasm-gen": "1.8.5",
+                "@webassemblyjs/wasm-parser": "1.8.5"
+            }
+        },
+        "@webassemblyjs/wasm-parser": {
+            "version": "1.8.5",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.8.5.tgz",
+            "integrity": "sha512-pi0SYE9T6tfcMkthwcgCpL0cM9nRYr6/6fjgDtL6q/ZqKHdMWvxitRi5JcZ7RI4SNJJYnYNaWy5UUrHQy998lw==",
+            "dev": true,
+            "requires": {
+                "@webassemblyjs/ast": "1.8.5",
+                "@webassemblyjs/helper-api-error": "1.8.5",
+                "@webassemblyjs/helper-wasm-bytecode": "1.8.5",
+                "@webassemblyjs/ieee754": "1.8.5",
+                "@webassemblyjs/leb128": "1.8.5",
+                "@webassemblyjs/utf8": "1.8.5"
+            }
+        },
+        "@webassemblyjs/wast-parser": {
+            "version": "1.8.5",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-parser/-/wast-parser-1.8.5.tgz",
+            "integrity": "sha512-daXC1FyKWHF1i11obK086QRlsMsY4+tIOKgBqI1lxAnkp9xe9YMcgOxm9kLe+ttjs5aWV2KKE1TWJCN57/Btsg==",
+            "dev": true,
+            "requires": {
+                "@webassemblyjs/ast": "1.8.5",
+                "@webassemblyjs/floating-point-hex-parser": "1.8.5",
+                "@webassemblyjs/helper-api-error": "1.8.5",
+                "@webassemblyjs/helper-code-frame": "1.8.5",
+                "@webassemblyjs/helper-fsm": "1.8.5",
+                "@xtuc/long": "4.2.2"
+            }
+        },
+        "@webassemblyjs/wast-printer": {
+            "version": "1.8.5",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.8.5.tgz",
+            "integrity": "sha512-w0U0pD4EhlnvRyeJzBqaVSJAo9w/ce7/WPogeXLzGkO6hzhr4GnQIZ4W4uUt5b9ooAaXPtnXlj0gzsXEOUNYMg==",
+            "dev": true,
+            "requires": {
+                "@webassemblyjs/ast": "1.8.5",
+                "@webassemblyjs/wast-parser": "1.8.5",
+                "@xtuc/long": "4.2.2"
+            }
+        },
+        "@xtuc/ieee754": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
+            "integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
+            "dev": true
+        },
+        "@xtuc/long": {
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
+            "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
+            "dev": true
+        },
+        "accepts": {
+            "version": "1.3.7",
+            "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
+            "integrity": "sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==",
+            "dev": true,
+            "requires": {
+                "mime-types": "2.1.24",
+                "negotiator": "0.6.2"
+            }
+        },
+        "acorn": {
+            "version": "6.2.1",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.2.1.tgz",
+            "integrity": "sha512-JD0xT5FCRDNyjDda3Lrg/IxFscp9q4tiYtxE1/nOzlKCk7hIRuYjhq1kCNkbPjMRMZuFq20HNQn1I9k8Oj0E+Q==",
+            "dev": true
+        },
+        "acorn-jsx": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.0.1.tgz",
+            "integrity": "sha512-HJ7CfNHrfJLlNTzIEUTj43LNWGkqpRLxm3YjAlcD0ACydk9XynzYsCBHxut+iqt+1aBXkx9UP/w/ZqMr13XIzg==",
+            "dev": true
+        },
+        "ajv": {
+            "version": "6.10.2",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
+            "integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
+            "dev": true,
+            "requires": {
+                "fast-deep-equal": "2.0.1",
+                "fast-json-stable-stringify": "2.0.0",
+                "json-schema-traverse": "0.4.1",
+                "uri-js": "4.2.2"
+            }
+        },
+        "ajv-errors": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.1.tgz",
+            "integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==",
+            "dev": true
+        },
+        "ajv-keywords": {
+            "version": "3.4.1",
+            "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.4.1.tgz",
+            "integrity": "sha512-RO1ibKvd27e6FEShVFfPALuHI3WjSVNeK5FIsmme/LYRNxjKuNj+Dt7bucLa6NdSv3JcVTyMlm9kGR84z1XpaQ==",
+            "dev": true
+        },
+        "alphanum-sort": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz",
+            "integrity": "sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM=",
+            "dev": true
+        },
+        "ansi-colors": {
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.4.tgz",
+            "integrity": "sha512-hHUXGagefjN2iRrID63xckIvotOXOojhQKWIPUZ4mNUZ9nLZW+7FMNoE1lOkEhNWYsx/7ysGIuJYCiMAA9FnrA==",
+            "dev": true
+        },
+        "ansi-escapes": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+            "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
+            "dev": true
+        },
+        "ansi-html": {
+            "version": "0.0.7",
+            "resolved": "https://registry.npmjs.org/ansi-html/-/ansi-html-0.0.7.tgz",
+            "integrity": "sha1-gTWEAhliqenm/QOflA0S9WynhZ4=",
+            "dev": true
+        },
+        "ansi-regex": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+            "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+            "dev": true
+        },
+        "ansi-styles": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+            "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+            "dev": true,
+            "requires": {
+                "color-convert": "1.9.3"
+            }
+        },
+        "anymatch": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
+            "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
+            "dev": true,
+            "requires": {
+                "micromatch": "3.1.10",
+                "normalize-path": "2.1.1"
+            },
+            "dependencies": {
+                "normalize-path": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+                    "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+                    "dev": true,
+                    "requires": {
+                        "remove-trailing-separator": "1.1.0"
+                    }
+                }
+            }
+        },
+        "aproba": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+            "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
+            "dev": true
+        },
+        "argparse": {
+            "version": "1.0.10",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+            "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+            "dev": true,
+            "requires": {
+                "sprintf-js": "1.0.3"
+            }
+        },
+        "aria-query": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-3.0.0.tgz",
+            "integrity": "sha1-ZbP8wcoRVajJrmTW7uKX8V1RM8w=",
+            "dev": true,
+            "requires": {
+                "ast-types-flow": "0.0.7",
+                "commander": "2.20.0"
+            }
+        },
+        "arr-diff": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+            "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+            "dev": true
+        },
+        "arr-flatten": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+            "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+            "dev": true
+        },
+        "arr-union": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+            "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
+            "dev": true
+        },
+        "array-find-index": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
+            "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
+            "dev": true
+        },
+        "array-flatten": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-2.1.2.tgz",
+            "integrity": "sha512-hNfzcOV8W4NdualtqBFPyVO+54DSJuZGY9qT4pRroB6S9e3iiido2ISIC5h9R2sPJ8H3FHCIiEnsv1lPXO3KtQ==",
+            "dev": true
+        },
+        "array-includes": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.0.3.tgz",
+            "integrity": "sha1-GEtI9i2S10UrsxsyMWXH+L0CJm0=",
+            "dev": true,
+            "requires": {
+                "define-properties": "1.1.3",
+                "es-abstract": "1.13.0"
+            }
+        },
+        "array-union": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+            "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+            "dev": true,
+            "requires": {
+                "array-uniq": "1.0.3"
+            }
+        },
+        "array-uniq": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+            "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
+            "dev": true
+        },
+        "array-unique": {
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+            "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+            "dev": true
+        },
+        "arrify": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+            "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+            "dev": true
+        },
+        "asn1.js": {
+            "version": "4.10.1",
+            "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
+            "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
+            "dev": true,
+            "requires": {
+                "bn.js": "4.11.8",
+                "inherits": "2.0.4",
+                "minimalistic-assert": "1.0.1"
+            }
+        },
+        "assert": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/assert/-/assert-1.5.0.tgz",
+            "integrity": "sha512-EDsgawzwoun2CZkCgtxJbv392v4nbk9XDD06zI+kQYoBM/3RBWLlEyJARDOmhAAosBjWACEkKL6S+lIZtcAubA==",
+            "dev": true,
+            "requires": {
+                "object-assign": "4.1.1",
+                "util": "0.10.3"
+            },
+            "dependencies": {
+                "inherits": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                    "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
+                    "dev": true
+                },
+                "util": {
+                    "version": "0.10.3",
+                    "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+                    "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
+                    "dev": true,
+                    "requires": {
+                        "inherits": "2.0.1"
+                    }
+                }
+            }
+        },
+        "assign-symbols": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
+            "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
+            "dev": true
+        },
+        "ast-types": {
+            "version": "0.9.6",
+            "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.9.6.tgz",
+            "integrity": "sha1-ECyenpAF0+fjgpvwxPok7oYu6bk=",
+            "dev": true
+        },
+        "ast-types-flow": {
+            "version": "0.0.7",
+            "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.7.tgz",
+            "integrity": "sha1-9wtzXGvKGlycItmCw+Oef+ujva0=",
+            "dev": true
+        },
+        "astral-regex": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
+            "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
+            "dev": true
+        },
+        "async": {
+            "version": "1.5.2",
+            "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+            "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+            "dev": true
+        },
+        "async-each": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.3.tgz",
+            "integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==",
+            "dev": true
+        },
+        "atob": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
+            "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
+            "dev": true
+        },
+        "autoprefixer": {
+            "version": "9.6.1",
+            "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.6.1.tgz",
+            "integrity": "sha512-aVo5WxR3VyvyJxcJC3h4FKfwCQvQWb1tSI5VHNibddCVWrcD1NvlxEweg3TSgiPztMnWfjpy2FURKA2kvDE+Tw==",
+            "dev": true,
+            "requires": {
+                "browserslist": "4.6.6",
+                "caniuse-lite": "1.0.30000985",
+                "chalk": "2.4.2",
+                "normalize-range": "0.1.2",
+                "num2fraction": "1.2.2",
+                "postcss": "7.0.17",
+                "postcss-value-parser": "4.0.0"
+            },
+            "dependencies": {
+                "postcss-value-parser": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.0.0.tgz",
+                    "integrity": "sha512-ESPktioptiSUchCKgggAkzdmkgzKfmp0EU8jXH+5kbIUB+unr0Y4CY9SRMvibuvYUBjNh1ACLbxqYNpdTQOteQ==",
+                    "dev": true
+                }
+            }
+        },
+        "axobject-query": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.0.2.tgz",
+            "integrity": "sha512-MCeek8ZH7hKyO1rWUbKNQBbl4l2eY0ntk7OGi+q0RlafrCnfPxC06WZA+uebCfmYp4mNU9jRBP1AhGyf8+W3ww==",
+            "dev": true,
+            "requires": {
+                "ast-types-flow": "0.0.7"
+            }
+        },
+        "babel-code-frame": {
+            "version": "6.26.0",
+            "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+            "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+            "dev": true,
+            "requires": {
+                "chalk": "1.1.3",
+                "esutils": "2.0.2",
+                "js-tokens": "3.0.2"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "2.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+                    "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+                    "dev": true
+                },
+                "chalk": {
+                    "version": "1.1.3",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                    "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "2.2.1",
+                        "escape-string-regexp": "1.0.5",
+                        "has-ansi": "2.0.0",
+                        "strip-ansi": "3.0.1",
+                        "supports-color": "2.0.0"
+                    }
+                },
+                "js-tokens": {
+                    "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+                    "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                    "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+                    "dev": true
+                }
+            }
+        },
+        "babel-eslint": {
+            "version": "10.0.2",
+            "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-10.0.2.tgz",
+            "integrity": "sha512-UdsurWPtgiPgpJ06ryUnuaSXC2s0WoSZnQmEpbAH65XZSdwowgN5MvyP7e88nW07FYXv72erVtpBkxyDVKhH1Q==",
+            "dev": true,
+            "requires": {
+                "@babel/code-frame": "7.5.5",
+                "@babel/parser": "7.5.5",
+                "@babel/traverse": "7.5.5",
+                "@babel/types": "7.5.5",
+                "eslint-scope": "3.7.1",
+                "eslint-visitor-keys": "1.0.0"
+            }
+        },
+        "babel-helper-function-name": {
+            "version": "6.24.1",
+            "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
+            "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
+            "dev": true,
+            "requires": {
+                "babel-helper-get-function-arity": "6.24.1",
+                "babel-runtime": "6.26.0",
+                "babel-template": "6.26.0",
+                "babel-traverse": "6.26.0",
+                "babel-types": "6.26.0"
+            }
+        },
+        "babel-helper-get-function-arity": {
+            "version": "6.24.1",
+            "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
+            "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
+            "dev": true,
+            "requires": {
+                "babel-runtime": "6.26.0",
+                "babel-types": "6.26.0"
+            }
+        },
+        "babel-loader": {
+            "version": "8.0.6",
+            "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-8.0.6.tgz",
+            "integrity": "sha512-4BmWKtBOBm13uoUwd08UwjZlaw3O9GWf456R9j+5YykFZ6LUIjIKLc0zEZf+hauxPOJs96C8k6FvYD09vWzhYw==",
+            "dev": true,
+            "requires": {
+                "find-cache-dir": "2.1.0",
+                "loader-utils": "1.2.3",
+                "mkdirp": "0.5.1",
+                "pify": "4.0.1"
+            }
+        },
+        "babel-messages": {
+            "version": "6.23.0",
+            "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+            "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
+            "dev": true,
+            "requires": {
+                "babel-runtime": "6.26.0"
+            }
+        },
+        "babel-plugin-dynamic-import-node": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.0.tgz",
+            "integrity": "sha512-o6qFkpeQEBxcqt0XYlWzAVxNCSCZdUgcR8IRlhD/8DylxjjO4foPcvTW0GGKa/cVt3rvxZ7o5ippJ+/0nvLhlQ==",
+            "dev": true,
+            "requires": {
+                "object.assign": "4.1.0"
+            }
+        },
+        "babel-plugin-syntax-class-properties": {
+            "version": "6.13.0",
+            "resolved": "https://registry.npmjs.org/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-6.13.0.tgz",
+            "integrity": "sha1-1+sjt5oxf4VDlixQW4J8fWysJ94=",
+            "dev": true
+        },
+        "babel-plugin-transform-class-properties": {
+            "version": "6.24.1",
+            "resolved": "https://registry.npmjs.org/babel-plugin-transform-class-properties/-/babel-plugin-transform-class-properties-6.24.1.tgz",
+            "integrity": "sha1-anl2PqYdM9NvN7YRqp3vgagbRqw=",
+            "dev": true,
+            "requires": {
+                "babel-helper-function-name": "6.24.1",
+                "babel-plugin-syntax-class-properties": "6.13.0",
+                "babel-runtime": "6.26.0",
+                "babel-template": "6.26.0"
+            }
+        },
+        "babel-runtime": {
+            "version": "6.26.0",
+            "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+            "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+            "dev": true,
+            "requires": {
+                "core-js": "2.6.9",
+                "regenerator-runtime": "0.11.1"
+            },
+            "dependencies": {
+                "regenerator-runtime": {
+                    "version": "0.11.1",
+                    "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+                    "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
+                    "dev": true
+                }
+            }
+        },
+        "babel-template": {
+            "version": "6.26.0",
+            "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
+            "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
+            "dev": true,
+            "requires": {
+                "babel-runtime": "6.26.0",
+                "babel-traverse": "6.26.0",
+                "babel-types": "6.26.0",
+                "babylon": "6.18.0",
+                "lodash": "4.17.15"
+            }
+        },
+        "babel-traverse": {
+            "version": "6.26.0",
+            "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
+            "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
+            "dev": true,
+            "requires": {
+                "babel-code-frame": "6.26.0",
+                "babel-messages": "6.23.0",
+                "babel-runtime": "6.26.0",
+                "babel-types": "6.26.0",
+                "babylon": "6.18.0",
+                "debug": "2.6.9",
+                "globals": "9.18.0",
+                "invariant": "2.2.4",
+                "lodash": "4.17.15"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "2.6.9",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
+                "globals": {
+                    "version": "9.18.0",
+                    "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
+                    "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
+                    "dev": true
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+                    "dev": true
+                }
+            }
+        },
+        "babel-types": {
+            "version": "6.26.0",
+            "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
+            "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
+            "dev": true,
+            "requires": {
+                "babel-runtime": "6.26.0",
+                "esutils": "2.0.2",
+                "lodash": "4.17.15",
+                "to-fast-properties": "1.0.3"
+            },
+            "dependencies": {
+                "to-fast-properties": {
+                    "version": "1.0.3",
+                    "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+                    "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
+                    "dev": true
+                }
+            }
+        },
+        "babylon": {
+            "version": "6.18.0",
+            "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
+            "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
+            "dev": true
+        },
+        "bail": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/bail/-/bail-1.0.4.tgz",
+            "integrity": "sha512-S8vuDB4w6YpRhICUDET3guPlQpaJl7od94tpZ0Fvnyp+MKW/HyDTcRDck+29C9g+d/qQHnddRH3+94kZdrW0Ww==",
+            "dev": true
+        },
+        "balanced-match": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+            "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+            "dev": true
+        },
+        "base": {
+            "version": "0.11.2",
+            "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
+            "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
+            "dev": true,
+            "requires": {
+                "cache-base": "1.0.1",
+                "class-utils": "0.3.6",
+                "component-emitter": "1.3.0",
+                "define-property": "1.0.0",
+                "isobject": "3.0.1",
+                "mixin-deep": "1.3.2",
+                "pascalcase": "0.1.1"
+            },
+            "dependencies": {
+                "define-property": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+                    "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+                    "dev": true,
+                    "requires": {
+                        "is-descriptor": "1.0.2"
+                    }
+                },
+                "is-accessor-descriptor": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+                    "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "6.0.2"
+                    }
+                },
+                "is-data-descriptor": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+                    "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "6.0.2"
+                    }
+                },
+                "is-descriptor": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+                    "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+                    "dev": true,
+                    "requires": {
+                        "is-accessor-descriptor": "1.0.0",
+                        "is-data-descriptor": "1.0.0",
+                        "kind-of": "6.0.2"
+                    }
+                }
+            }
+        },
+        "base64-js": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
+            "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw==",
+            "dev": true
+        },
+        "batch": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
+            "integrity": "sha1-3DQxT05nkxgJP8dgJyUl+UvyXBY=",
+            "dev": true
+        },
+        "big.js": {
+            "version": "5.2.2",
+            "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
+            "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ=="
+        },
+        "binary-extensions": {
+            "version": "1.13.1",
+            "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
+            "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
+            "dev": true
+        },
+        "bluebird": {
+            "version": "3.5.5",
+            "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.5.tgz",
+            "integrity": "sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w==",
+            "dev": true
+        },
+        "bn.js": {
+            "version": "4.11.8",
+            "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+            "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
+            "dev": true
+        },
+        "body-parser": {
+            "version": "1.19.0",
+            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.0.tgz",
+            "integrity": "sha512-dhEPs72UPbDnAQJ9ZKMNTP6ptJaionhP5cBb541nXPlW60Jepo9RV/a4fX4XWW9CuFNK22krhrj1+rgzifNCsw==",
+            "dev": true,
+            "requires": {
+                "bytes": "3.1.0",
+                "content-type": "1.0.4",
+                "debug": "2.6.9",
+                "depd": "1.1.2",
+                "http-errors": "1.7.2",
+                "iconv-lite": "0.4.24",
+                "on-finished": "2.3.0",
+                "qs": "6.7.0",
+                "raw-body": "2.4.0",
+                "type-is": "1.6.18"
+            },
+            "dependencies": {
+                "bytes": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
+                    "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==",
+                    "dev": true
+                },
+                "debug": {
+                    "version": "2.6.9",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+                    "dev": true
+                }
+            }
+        },
+        "bonjour": {
+            "version": "3.5.0",
+            "resolved": "https://registry.npmjs.org/bonjour/-/bonjour-3.5.0.tgz",
+            "integrity": "sha1-jokKGD2O6aI5OzhExpGkK897yfU=",
+            "dev": true,
+            "requires": {
+                "array-flatten": "2.1.2",
+                "deep-equal": "1.0.1",
+                "dns-equal": "1.0.0",
+                "dns-txt": "2.0.2",
+                "multicast-dns": "6.2.3",
+                "multicast-dns-service-types": "1.1.0"
+            }
+        },
+        "boolbase": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+            "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
+            "dev": true
+        },
+        "brace-expansion": {
+            "version": "1.1.11",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "dev": true,
+            "requires": {
+                "balanced-match": "1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
+        "braces": {
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+            "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+            "dev": true,
+            "requires": {
+                "arr-flatten": "1.1.0",
+                "array-unique": "0.3.2",
+                "extend-shallow": "2.0.1",
+                "fill-range": "4.0.0",
+                "isobject": "3.0.1",
+                "repeat-element": "1.1.3",
+                "snapdragon": "0.8.2",
+                "snapdragon-node": "2.1.1",
+                "split-string": "3.1.0",
+                "to-regex": "3.0.2"
+            },
+            "dependencies": {
+                "extend-shallow": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                    "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                    "dev": true,
+                    "requires": {
+                        "is-extendable": "0.1.1"
+                    }
+                }
+            }
+        },
+        "brorand": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+            "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
+            "dev": true
+        },
+        "browserify-aes": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+            "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
+            "dev": true,
+            "requires": {
+                "buffer-xor": "1.0.3",
+                "cipher-base": "1.0.4",
+                "create-hash": "1.2.0",
+                "evp_bytestokey": "1.0.3",
+                "inherits": "2.0.4",
+                "safe-buffer": "5.1.2"
+            }
+        },
+        "browserify-cipher": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.1.tgz",
+            "integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
+            "dev": true,
+            "requires": {
+                "browserify-aes": "1.2.0",
+                "browserify-des": "1.0.2",
+                "evp_bytestokey": "1.0.3"
+            }
+        },
+        "browserify-des": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.2.tgz",
+            "integrity": "sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==",
+            "dev": true,
+            "requires": {
+                "cipher-base": "1.0.4",
+                "des.js": "1.0.0",
+                "inherits": "2.0.4",
+                "safe-buffer": "5.1.2"
+            }
+        },
+        "browserify-rsa": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+            "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
+            "dev": true,
+            "requires": {
+                "bn.js": "4.11.8",
+                "randombytes": "2.1.0"
+            }
+        },
+        "browserify-sign": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.4.tgz",
+            "integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
+            "dev": true,
+            "requires": {
+                "bn.js": "4.11.8",
+                "browserify-rsa": "4.0.1",
+                "create-hash": "1.2.0",
+                "create-hmac": "1.1.7",
+                "elliptic": "6.5.0",
+                "inherits": "2.0.4",
+                "parse-asn1": "5.1.4"
+            }
+        },
+        "browserify-zlib": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
+            "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
+            "dev": true,
+            "requires": {
+                "pako": "1.0.10"
+            }
+        },
+        "browserslist": {
+            "version": "4.6.6",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.6.6.tgz",
+            "integrity": "sha512-D2Nk3W9JL9Fp/gIcWei8LrERCS+eXu9AM5cfXA8WEZ84lFks+ARnZ0q/R69m2SV3Wjma83QDDPxsNKXUwdIsyA==",
+            "dev": true,
+            "requires": {
+                "caniuse-lite": "1.0.30000985",
+                "electron-to-chromium": "1.3.199",
+                "node-releases": "1.1.25"
+            }
+        },
+        "buffer": {
+            "version": "4.9.1",
+            "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+            "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
+            "dev": true,
+            "requires": {
+                "base64-js": "1.3.0",
+                "ieee754": "1.1.13",
+                "isarray": "1.0.0"
+            },
+            "dependencies": {
+                "isarray": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                    "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+                    "dev": true
+                }
+            }
+        },
+        "buffer-from": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+            "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+            "dev": true
+        },
+        "buffer-indexof": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/buffer-indexof/-/buffer-indexof-1.1.1.tgz",
+            "integrity": "sha512-4/rOEg86jivtPTeOUUT61jJO1Ya1TrR/OkqCSZDyq84WJh3LuuiphBYJN+fm5xufIk4XAFcEwte/8WzC8If/1g==",
+            "dev": true
+        },
+        "buffer-xor": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
+            "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=",
+            "dev": true
+        },
+        "builtin-status-codes": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
+            "integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=",
+            "dev": true
+        },
+        "bytes": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
+            "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=",
+            "dev": true
+        },
+        "cacache": {
+            "version": "11.3.3",
+            "resolved": "https://registry.npmjs.org/cacache/-/cacache-11.3.3.tgz",
+            "integrity": "sha512-p8WcneCytvzPxhDvYp31PD039vi77I12W+/KfR9S8AZbaiARFBCpsPJS+9uhWfeBfeAtW7o/4vt3MUqLkbY6nA==",
+            "dev": true,
+            "requires": {
+                "bluebird": "3.5.5",
+                "chownr": "1.1.2",
+                "figgy-pudding": "3.5.1",
+                "glob": "7.1.4",
+                "graceful-fs": "4.2.0",
+                "lru-cache": "5.1.1",
+                "mississippi": "3.0.0",
+                "mkdirp": "0.5.1",
+                "move-concurrently": "1.0.1",
+                "promise-inflight": "1.0.1",
+                "rimraf": "2.6.3",
+                "ssri": "6.0.1",
+                "unique-filename": "1.1.1",
+                "y18n": "4.0.0"
+            }
+        },
+        "cache-base": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
+            "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
+            "dev": true,
+            "requires": {
+                "collection-visit": "1.0.0",
+                "component-emitter": "1.3.0",
+                "get-value": "2.0.6",
+                "has-value": "1.0.0",
+                "isobject": "3.0.1",
+                "set-value": "2.0.1",
+                "to-object-path": "0.3.0",
+                "union-value": "1.0.1",
+                "unset-value": "1.0.0"
+            }
+        },
+        "call-me-maybe": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
+            "integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms=",
+            "dev": true
+        },
+        "caller-callsite": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/caller-callsite/-/caller-callsite-2.0.0.tgz",
+            "integrity": "sha1-hH4PzgoiN1CpoCfFSzNzGtMVQTQ=",
+            "dev": true,
+            "requires": {
+                "callsites": "2.0.0"
+            }
+        },
+        "caller-path": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-2.0.0.tgz",
+            "integrity": "sha1-Ro+DBE42mrIBD6xfBs7uFbsssfQ=",
+            "dev": true,
+            "requires": {
+                "caller-callsite": "2.0.0"
+            }
+        },
+        "callsites": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
+            "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
+            "dev": true
+        },
+        "camel-case": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-3.0.0.tgz",
+            "integrity": "sha1-yjw2iKTpzzpM2nd9xNy8cTJJz3M=",
+            "dev": true,
+            "requires": {
+                "no-case": "2.3.2",
+                "upper-case": "1.1.3"
+            }
+        },
+        "camelcase": {
+            "version": "5.3.1",
+            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+            "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+            "dev": true
+        },
+        "camelcase-keys": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-4.2.0.tgz",
+            "integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
+            "dev": true,
+            "requires": {
+                "camelcase": "4.1.0",
+                "map-obj": "2.0.0",
+                "quick-lru": "1.1.0"
+            },
+            "dependencies": {
+                "camelcase": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+                    "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+                    "dev": true
+                }
+            }
+        },
+        "caniuse-api": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-3.0.0.tgz",
+            "integrity": "sha512-bsTwuIg/BZZK/vreVTYYbSWoe2F+71P7K5QGEX+pT250DZbfU1MQ5prOKpPR+LL6uWKK3KMwMCAS74QB3Um1uw==",
+            "dev": true,
+            "requires": {
+                "browserslist": "4.6.6",
+                "caniuse-lite": "1.0.30000985",
+                "lodash.memoize": "4.1.2",
+                "lodash.uniq": "4.5.0"
+            }
+        },
+        "caniuse-lite": {
+            "version": "1.0.30000985",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000985.tgz",
+            "integrity": "sha512-1ngiwkgqAYPG0JSSUp3PUDGPKKY59EK7NrGGX+VOxaKCNzRbNc7uXMny+c3VJfZxtoK3wSImTvG9T9sXiTw2+w==",
+            "dev": true
+        },
+        "ccount": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/ccount/-/ccount-1.0.4.tgz",
+            "integrity": "sha512-fpZ81yYfzentuieinmGnphk0pLkOTMm6MZdVqwd77ROvhko6iujLNGrHH5E7utq3ygWklwfmwuG+A7P+NpqT6w==",
+            "dev": true
+        },
+        "chalk": {
+            "version": "2.4.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+            "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+            "dev": true,
+            "requires": {
+                "ansi-styles": "3.2.1",
+                "escape-string-regexp": "1.0.5",
+                "supports-color": "5.5.0"
+            }
+        },
+        "character-entities": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.3.tgz",
+            "integrity": "sha512-yB4oYSAa9yLcGyTbB4ItFwHw43QHdH129IJ5R+WvxOkWlyFnR5FAaBNnUq4mcxsTVZGh28bHoeTHMKXH1wZf3w==",
+            "dev": true
+        },
+        "character-entities-html4": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-1.1.3.tgz",
+            "integrity": "sha512-SwnyZ7jQBCRHELk9zf2CN5AnGEc2nA+uKMZLHvcqhpPprjkYhiLn0DywMHgN5ttFZuITMATbh68M6VIVKwJbcg==",
+            "dev": true
+        },
+        "character-entities-legacy": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-1.1.3.tgz",
+            "integrity": "sha512-YAxUpPoPwxYFsslbdKkhrGnXAtXoHNgYjlBM3WMXkWGTl5RsY3QmOyhwAgL8Nxm9l5LBThXGawxKPn68y6/fww==",
+            "dev": true
+        },
+        "character-reference-invalid": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.3.tgz",
+            "integrity": "sha512-VOq6PRzQBam/8Jm6XBGk2fNEnHXAdGd6go0rtd4weAGECBamHDwwCQSOT12TACIYUZegUXnV6xBXqUssijtxIg==",
+            "dev": true
+        },
+        "chardet": {
+            "version": "0.7.0",
+            "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+            "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+            "dev": true
+        },
+        "chokidar": {
+            "version": "2.1.6",
+            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.6.tgz",
+            "integrity": "sha512-V2jUo67OKkc6ySiRpJrjlpJKl9kDuG+Xb8VgsGzb+aEouhgS1D0weyPU4lEzdAcsCAvrih2J2BqyXqHWvVLw5g==",
+            "dev": true,
+            "requires": {
+                "anymatch": "2.0.0",
+                "async-each": "1.0.3",
+                "braces": "2.3.2",
+                "fsevents": "1.2.9",
+                "glob-parent": "3.1.0",
+                "inherits": "2.0.4",
+                "is-binary-path": "1.0.1",
+                "is-glob": "4.0.1",
+                "normalize-path": "3.0.0",
+                "path-is-absolute": "1.0.1",
+                "readdirp": "2.2.1",
+                "upath": "1.1.2"
+            }
+        },
+        "chownr": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.2.tgz",
+            "integrity": "sha512-GkfeAQh+QNy3wquu9oIZr6SS5x7wGdSgNQvD10X3r+AZr1Oys22HW8kAmDMvNg2+Dm0TeGaEuO8gFwdBXxwO8A==",
+            "dev": true
+        },
+        "chrome-trace-event": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.2.tgz",
+            "integrity": "sha512-9e/zx1jw7B4CO+c/RXoCsfg/x1AfUBioy4owYH0bJprEYAx5hRFLRhWBqHAG57D0ZM4H7vxbP7bPe0VwhQRYDQ==",
+            "dev": true,
+            "requires": {
+                "tslib": "1.10.0"
+            }
+        },
+        "cipher-base": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
+            "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
+            "dev": true,
+            "requires": {
+                "inherits": "2.0.4",
+                "safe-buffer": "5.1.2"
+            }
+        },
+        "class-utils": {
+            "version": "0.3.6",
+            "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
+            "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
+            "dev": true,
+            "requires": {
+                "arr-union": "3.1.0",
+                "define-property": "0.2.5",
+                "isobject": "3.0.1",
+                "static-extend": "0.1.2"
+            },
+            "dependencies": {
+                "define-property": {
+                    "version": "0.2.5",
+                    "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+                    "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+                    "dev": true,
+                    "requires": {
+                        "is-descriptor": "0.1.6"
+                    }
+                }
+            }
+        },
+        "clean-css": {
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.2.1.tgz",
+            "integrity": "sha512-4ZxI6dy4lrY6FHzfiy1aEOXgu4LIsW2MhwG0VBKdcoGoH/XLFgaHSdLTGr4O8Be6A8r3MOphEiI8Gc1n0ecf3g==",
+            "dev": true,
+            "requires": {
+                "source-map": "0.6.1"
+            },
+            "dependencies": {
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
+                }
+            }
+        },
+        "clean-webpack-plugin": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/clean-webpack-plugin/-/clean-webpack-plugin-3.0.0.tgz",
+            "integrity": "sha512-MciirUH5r+cYLGCOL5JX/ZLzOZbVr1ot3Fw+KcvbhUb6PM+yycqd9ZhIlcigQ5gl+XhppNmw3bEFuaaMNyLj3A==",
+            "dev": true,
+            "requires": {
+                "@types/webpack": "4.32.0",
+                "del": "4.1.1"
+            }
+        },
+        "cli-cursor": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+            "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+            "dev": true,
+            "requires": {
+                "restore-cursor": "2.0.0"
+            }
+        },
+        "cli-width": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
+            "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
+            "dev": true
+        },
+        "cliui": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+            "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+            "dev": true,
+            "requires": {
+                "string-width": "3.1.0",
+                "strip-ansi": "5.2.0",
+                "wrap-ansi": "5.1.0"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+                    "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+                    "dev": true
+                },
+                "string-width": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+                    "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+                    "dev": true,
+                    "requires": {
+                        "emoji-regex": "7.0.3",
+                        "is-fullwidth-code-point": "2.0.0",
+                        "strip-ansi": "5.2.0"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+                    "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "4.1.0"
+                    }
+                }
+            }
+        },
+        "clone-regexp": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/clone-regexp/-/clone-regexp-2.2.0.tgz",
+            "integrity": "sha512-beMpP7BOtTipFuW8hrJvREQ2DrRu3BE7by0ZpibtfBA+qfHYvMGTc2Yb1JMYPKg/JUw0CHYvpg796aNTSW9z7Q==",
+            "dev": true,
+            "requires": {
+                "is-regexp": "2.1.0"
+            }
+        },
+        "coa": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/coa/-/coa-2.0.2.tgz",
+            "integrity": "sha512-q5/jG+YQnSy4nRTV4F7lPepBJZ8qBNJJDBuJdoejDyLXgmL7IEo+Le2JDZudFTFt7mrCqIRaSjws4ygRCTCAXA==",
+            "dev": true,
+            "requires": {
+                "@types/q": "1.5.2",
+                "chalk": "2.4.2",
+                "q": "1.5.1"
+            }
+        },
+        "code-point-at": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+            "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+            "dev": true
+        },
+        "collapse-white-space": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/collapse-white-space/-/collapse-white-space-1.0.5.tgz",
+            "integrity": "sha512-703bOOmytCYAX9cXYqoikYIx6twmFCXsnzRQheBcTG3nzKYBR4P/+wkYeH+Mvj7qUz8zZDtdyzbxfnEi/kYzRQ==",
+            "dev": true
+        },
+        "collection-visit": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
+            "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
+            "dev": true,
+            "requires": {
+                "map-visit": "1.0.0",
+                "object-visit": "1.0.1"
+            }
+        },
+        "color": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/color/-/color-3.1.2.tgz",
+            "integrity": "sha512-vXTJhHebByxZn3lDvDJYw4lR5+uB3vuoHsuYA5AKuxRVn5wzzIfQKGLBmgdVRHKTJYeK5rvJcHnrd0Li49CFpg==",
+            "dev": true,
+            "requires": {
+                "color-convert": "1.9.3",
+                "color-string": "1.5.3"
+            }
+        },
+        "color-convert": {
+            "version": "1.9.3",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+            "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+            "dev": true,
+            "requires": {
+                "color-name": "1.1.3"
+            }
+        },
+        "color-name": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+            "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+            "dev": true
+        },
+        "color-string": {
+            "version": "1.5.3",
+            "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.3.tgz",
+            "integrity": "sha512-dC2C5qeWoYkxki5UAXapdjqO672AM4vZuPGRQfO8b5HKuKGBbKWpITyDYN7TOFKvRW7kOgAn3746clDBMDJyQw==",
+            "dev": true,
+            "requires": {
+                "color-name": "1.1.3",
+                "simple-swizzle": "0.2.2"
+            }
+        },
+        "commander": {
+            "version": "2.20.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
+            "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
+            "dev": true
+        },
+        "commondir": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+            "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
+            "dev": true
+        },
+        "component-emitter": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
+            "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
+            "dev": true
+        },
+        "compressible": {
+            "version": "2.0.17",
+            "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.17.tgz",
+            "integrity": "sha512-BGHeLCK1GV7j1bSmQQAi26X+GgWcTjLr/0tzSvMCl3LH1w1IJ4PFSPoV5316b30cneTziC+B1a+3OjoSUcQYmw==",
+            "dev": true,
+            "requires": {
+                "mime-db": "1.40.0"
+            }
+        },
+        "compression": {
+            "version": "1.7.4",
+            "resolved": "https://registry.npmjs.org/compression/-/compression-1.7.4.tgz",
+            "integrity": "sha512-jaSIDzP9pZVS4ZfQ+TzvtiWhdpFhE2RDHz8QJkpX9SIpLq88VueF5jJw6t+6CUQcAoA6t+x89MLrWAqpfDE8iQ==",
+            "dev": true,
+            "requires": {
+                "accepts": "1.3.7",
+                "bytes": "3.0.0",
+                "compressible": "2.0.17",
+                "debug": "2.6.9",
+                "on-headers": "1.0.2",
+                "safe-buffer": "5.1.2",
+                "vary": "1.1.2"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "2.6.9",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+                    "dev": true
+                }
+            }
+        },
+        "concat-map": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+            "dev": true
+        },
+        "concat-stream": {
+            "version": "1.6.2",
+            "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+            "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+            "dev": true,
+            "requires": {
+                "buffer-from": "1.1.1",
+                "inherits": "2.0.4",
+                "readable-stream": "2.3.6",
+                "typedarray": "0.0.6"
+            },
+            "dependencies": {
+                "isarray": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                    "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+                    "dev": true
+                },
+                "readable-stream": {
+                    "version": "2.3.6",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+                    "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+                    "dev": true,
+                    "requires": {
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.4",
+                        "isarray": "1.0.0",
+                        "process-nextick-args": "2.0.1",
+                        "safe-buffer": "5.1.2",
+                        "string_decoder": "1.1.1",
+                        "util-deprecate": "1.0.2"
+                    }
+                },
+                "string_decoder": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+                    "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+                    "dev": true,
+                    "requires": {
+                        "safe-buffer": "5.1.2"
+                    }
+                }
+            }
+        },
+        "confusing-browser-globals": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/confusing-browser-globals/-/confusing-browser-globals-1.0.7.tgz",
+            "integrity": "sha512-cgHI1azax5ATrZ8rJ+ODDML9Fvu67PimB6aNxBrc/QwSaDaM9eTfIEUHx3bBLJJ82ioSb+/5zfsMCCEJax3ByQ==",
+            "dev": true
+        },
+        "connect-history-api-fallback": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.6.0.tgz",
+            "integrity": "sha512-e54B99q/OUoH64zYYRf3HBP5z24G38h5D3qXu23JGRoigpX5Ss4r9ZnDk3g0Z8uQC2x2lPaJ+UlWBc1ZWBWdLg==",
+            "dev": true
+        },
+        "console-browserify": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
+            "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
+            "dev": true,
+            "requires": {
+                "date-now": "0.1.4"
+            }
+        },
+        "constants-browserify": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
+            "integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U=",
+            "dev": true
+        },
+        "contains-path": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
+            "integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=",
+            "dev": true
+        },
+        "content-disposition": {
+            "version": "0.5.3",
+            "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.3.tgz",
+            "integrity": "sha512-ExO0774ikEObIAEV9kDo50o+79VCUdEB6n6lzKgGwupcVeRlhrj3qGAfwq8G6uBJjkqLrhT0qEYFcWng8z1z0g==",
+            "dev": true,
+            "requires": {
+                "safe-buffer": "5.1.2"
+            }
+        },
+        "content-type": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
+            "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
+            "dev": true
+        },
+        "convert-source-map": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.6.0.tgz",
+            "integrity": "sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==",
+            "dev": true,
+            "requires": {
+                "safe-buffer": "5.1.2"
+            }
+        },
+        "cookie": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
+            "integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg==",
+            "dev": true
+        },
+        "cookie-signature": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+            "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw=",
+            "dev": true
+        },
+        "copy-concurrently": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/copy-concurrently/-/copy-concurrently-1.0.5.tgz",
+            "integrity": "sha512-f2domd9fsVDFtaFcbaRZuYXwtdmnzqbADSwhSWYxYB/Q8zsdUUFMXVRwXGDMWmbEzAn1kdRrtI1T/KTFOL4X2A==",
+            "dev": true,
+            "requires": {
+                "aproba": "1.2.0",
+                "fs-write-stream-atomic": "1.0.10",
+                "iferr": "0.1.5",
+                "mkdirp": "0.5.1",
+                "rimraf": "2.6.3",
+                "run-queue": "1.0.3"
+            }
+        },
+        "copy-descriptor": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
+            "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
+            "dev": true
+        },
+        "core-js": {
+            "version": "2.6.9",
+            "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.9.tgz",
+            "integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A==",
+            "dev": true
+        },
+        "core-js-compat": {
+            "version": "3.1.4",
+            "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.1.4.tgz",
+            "integrity": "sha512-Z5zbO9f1d0YrJdoaQhphVAnKPimX92D6z8lCGphH89MNRxlL1prI9ExJPqVwP0/kgkQCv8c4GJGT8X16yUncOg==",
+            "dev": true,
+            "requires": {
+                "browserslist": "4.6.6",
+                "core-js-pure": "3.1.4",
+                "semver": "6.3.0"
+            },
+            "dependencies": {
+                "semver": {
+                    "version": "6.3.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+                    "dev": true
+                }
+            }
+        },
+        "core-js-pure": {
+            "version": "3.1.4",
+            "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.1.4.tgz",
+            "integrity": "sha512-uJ4Z7iPNwiu1foygbcZYJsJs1jiXrTTCvxfLDXNhI/I+NHbSIEyr548y4fcsCEyWY0XgfAG/qqaunJ1SThHenA==",
+            "dev": true
+        },
+        "core-util-is": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+            "dev": true
+        },
+        "cosmiconfig": {
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.2.1.tgz",
+            "integrity": "sha512-H65gsXo1SKjf8zmrJ67eJk8aIRKV5ff2D4uKZIBZShbhGSpEmsQOPW/SKMKYhSTrqR7ufy6RP69rPogdaPh/kA==",
+            "dev": true,
+            "requires": {
+                "import-fresh": "2.0.0",
+                "is-directory": "0.3.1",
+                "js-yaml": "3.13.1",
+                "parse-json": "4.0.0"
+            }
+        },
+        "create-ecdh": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.3.tgz",
+            "integrity": "sha512-GbEHQPMOswGpKXM9kCWVrremUcBmjteUaQ01T9rkKCPDXfUHX0IoP9LpHYo2NPFampa4e+/pFDc3jQdxrxQLaw==",
+            "dev": true,
+            "requires": {
+                "bn.js": "4.11.8",
+                "elliptic": "6.5.0"
+            }
+        },
+        "create-hash": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+            "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
+            "dev": true,
+            "requires": {
+                "cipher-base": "1.0.4",
+                "inherits": "2.0.4",
+                "md5.js": "1.3.5",
+                "ripemd160": "2.0.2",
+                "sha.js": "2.4.11"
+            }
+        },
+        "create-hmac": {
+            "version": "1.1.7",
+            "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+            "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
+            "dev": true,
+            "requires": {
+                "cipher-base": "1.0.4",
+                "create-hash": "1.2.0",
+                "inherits": "2.0.4",
+                "ripemd160": "2.0.2",
+                "safe-buffer": "5.1.2",
+                "sha.js": "2.4.11"
+            }
+        },
+        "cross-spawn": {
+            "version": "6.0.5",
+            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+            "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+            "dev": true,
+            "requires": {
+                "nice-try": "1.0.5",
+                "path-key": "2.0.1",
+                "semver": "5.7.0",
+                "shebang-command": "1.2.0",
+                "which": "1.3.1"
+            }
+        },
+        "crypto-browserify": {
+            "version": "3.12.0",
+            "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
+            "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
+            "dev": true,
+            "requires": {
+                "browserify-cipher": "1.0.1",
+                "browserify-sign": "4.0.4",
+                "create-ecdh": "4.0.3",
+                "create-hash": "1.2.0",
+                "create-hmac": "1.1.7",
+                "diffie-hellman": "5.0.3",
+                "inherits": "2.0.4",
+                "pbkdf2": "3.0.17",
+                "public-encrypt": "4.0.3",
+                "randombytes": "2.1.0",
+                "randomfill": "1.0.4"
+            }
+        },
+        "css-blank-pseudo": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/css-blank-pseudo/-/css-blank-pseudo-0.1.4.tgz",
+            "integrity": "sha512-LHz35Hr83dnFeipc7oqFDmsjHdljj3TQtxGGiNWSOsTLIAubSm4TEz8qCaKFpk7idaQ1GfWscF4E6mgpBysA1w==",
+            "dev": true,
+            "requires": {
+                "postcss": "7.0.17"
+            }
+        },
+        "css-color-names": {
+            "version": "0.0.4",
+            "resolved": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz",
+            "integrity": "sha1-gIrcLnnPhHOAabZGyyDsJ762KeA=",
+            "dev": true
+        },
+        "css-declaration-sorter": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-4.0.1.tgz",
+            "integrity": "sha512-BcxQSKTSEEQUftYpBVnsH4SF05NTuBokb19/sBt6asXGKZ/6VP7PLG1CBCkFDYOnhXhPh0jMhO6xZ71oYHXHBA==",
+            "dev": true,
+            "requires": {
+                "postcss": "7.0.17",
+                "timsort": "0.3.0"
+            }
+        },
+        "css-has-pseudo": {
+            "version": "0.10.0",
+            "resolved": "https://registry.npmjs.org/css-has-pseudo/-/css-has-pseudo-0.10.0.tgz",
+            "integrity": "sha512-Z8hnfsZu4o/kt+AuFzeGpLVhFOGO9mluyHBaA2bA8aCGTwah5sT3WV/fTHH8UNZUytOIImuGPrl/prlb4oX4qQ==",
+            "dev": true,
+            "requires": {
+                "postcss": "7.0.17",
+                "postcss-selector-parser": "5.0.0"
+            },
+            "dependencies": {
+                "cssesc": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-2.0.0.tgz",
+                    "integrity": "sha512-MsCAG1z9lPdoO/IUMLSBWBSVxVtJ1395VGIQ+Fc2gNdkQ1hNDnQdw3YhA71WJCBW1vdwA0cAnk/DnW6bqoEUYg==",
+                    "dev": true
+                },
+                "postcss-selector-parser": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-5.0.0.tgz",
+                    "integrity": "sha512-w+zLE5Jhg6Liz8+rQOWEAwtwkyqpfnmsinXjXg6cY7YIONZZtgvE0v2O0uhQBs0peNomOJwWRKt6JBfTdTd3OQ==",
+                    "dev": true,
+                    "requires": {
+                        "cssesc": "2.0.0",
+                        "indexes-of": "1.0.1",
+                        "uniq": "1.0.1"
+                    }
+                }
+            }
+        },
+        "css-loader": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-3.1.0.tgz",
+            "integrity": "sha512-MuL8WsF/KSrHCBCYaozBKlx+r7vIfUaDTEreo7wR7Vv3J6N0z6fqWjRk3e/6wjneitXN1r/Y9FTK1psYNOBdJQ==",
+            "dev": true,
+            "requires": {
+                "camelcase": "5.3.1",
+                "cssesc": "3.0.0",
+                "icss-utils": "4.1.1",
+                "loader-utils": "1.2.3",
+                "normalize-path": "3.0.0",
+                "postcss": "7.0.17",
+                "postcss-modules-extract-imports": "2.0.0",
+                "postcss-modules-local-by-default": "3.0.2",
+                "postcss-modules-scope": "2.1.0",
+                "postcss-modules-values": "3.0.0",
+                "postcss-value-parser": "4.0.0",
+                "schema-utils": "2.0.1"
+            },
+            "dependencies": {
+                "postcss-value-parser": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.0.0.tgz",
+                    "integrity": "sha512-ESPktioptiSUchCKgggAkzdmkgzKfmp0EU8jXH+5kbIUB+unr0Y4CY9SRMvibuvYUBjNh1ACLbxqYNpdTQOteQ==",
+                    "dev": true
+                },
+                "schema-utils": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.0.1.tgz",
+                    "integrity": "sha512-HJFKJ4JixDpRur06QHwi8uu2kZbng318ahWEKgBjc0ZklcE4FDvmm2wghb448q0IRaABxIESt8vqPFvwgMB80A==",
+                    "dev": true,
+                    "requires": {
+                        "ajv": "6.10.2",
+                        "ajv-keywords": "3.4.1"
+                    }
+                }
+            }
+        },
+        "css-mqpacker": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/css-mqpacker/-/css-mqpacker-7.0.0.tgz",
+            "integrity": "sha512-temVrWS+sB4uocE2quhW8ru/KguDmGhCU7zN213KxtDvWOH3WS/ZUStfpF4fdCT7W8fPpFrQdWRFqtFtPPfBLA==",
+            "dev": true,
+            "requires": {
+                "minimist": "1.2.0",
+                "postcss": "7.0.17"
+            }
+        },
+        "css-prefers-color-scheme": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/css-prefers-color-scheme/-/css-prefers-color-scheme-3.1.1.tgz",
+            "integrity": "sha512-MTu6+tMs9S3EUqzmqLXEcgNRbNkkD/TGFvowpeoWJn5Vfq7FMgsmRQs9X5NXAURiOBmOxm/lLjsDNXDE6k9bhg==",
+            "dev": true,
+            "requires": {
+                "postcss": "7.0.17"
+            }
+        },
+        "css-select": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/css-select/-/css-select-2.0.2.tgz",
+            "integrity": "sha512-dSpYaDVoWaELjvZ3mS6IKZM/y2PMPa/XYoEfYNZePL4U/XgyxZNroHEHReDx/d+VgXh9VbCTtFqLkFbmeqeaRQ==",
+            "dev": true,
+            "requires": {
+                "boolbase": "1.0.0",
+                "css-what": "2.1.3",
+                "domutils": "1.7.0",
+                "nth-check": "1.0.2"
+            }
+        },
+        "css-select-base-adapter": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/css-select-base-adapter/-/css-select-base-adapter-0.1.1.tgz",
+            "integrity": "sha512-jQVeeRG70QI08vSTwf1jHxp74JoZsr2XSgETae8/xC8ovSnL2WF87GTLO86Sbwdt2lK4Umg4HnnwMO4YF3Ce7w==",
+            "dev": true
+        },
+        "css-tree": {
+            "version": "1.0.0-alpha.33",
+            "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.0.0-alpha.33.tgz",
+            "integrity": "sha512-SPt57bh5nQnpsTBsx/IXbO14sRc9xXu5MtMAVuo0BaQQmyf0NupNPPSoMaqiAF5tDFafYsTkfeH4Q/HCKXkg4w==",
+            "dev": true,
+            "requires": {
+                "mdn-data": "2.0.4",
+                "source-map": "0.5.7"
+            },
+            "dependencies": {
+                "source-map": {
+                    "version": "0.5.7",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+                    "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+                    "dev": true
+                }
+            }
+        },
+        "css-unit-converter": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/css-unit-converter/-/css-unit-converter-1.1.1.tgz",
+            "integrity": "sha1-2bkoGtz9jO2TW9urqDeGiX9k6ZY=",
+            "dev": true
+        },
+        "css-what": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.3.tgz",
+            "integrity": "sha512-a+EPoD+uZiNfh+5fxw2nO9QwFa6nJe2Or35fGY6Ipw1R3R4AGz1d1TEZrCegvw2YTmZ0jXirGYlzxxpYSHwpEg==",
+            "dev": true
+        },
+        "cssdb": {
+            "version": "4.4.0",
+            "resolved": "https://registry.npmjs.org/cssdb/-/cssdb-4.4.0.tgz",
+            "integrity": "sha512-LsTAR1JPEM9TpGhl/0p3nQecC2LJ0kD8X5YARu1hk/9I1gril5vDtMZyNxcEpxxDj34YNck/ucjuoUd66K03oQ==",
+            "dev": true
+        },
+        "cssesc": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+            "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+            "dev": true
+        },
+        "cssnano": {
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-4.1.10.tgz",
+            "integrity": "sha512-5wny+F6H4/8RgNlaqab4ktc3e0/blKutmq8yNlBFXA//nSFFAqAngjNVRzUvCgYROULmZZUoosL/KSoZo5aUaQ==",
+            "dev": true,
+            "requires": {
+                "cosmiconfig": "5.2.1",
+                "cssnano-preset-default": "4.0.7",
+                "is-resolvable": "1.1.0",
+                "postcss": "7.0.17"
+            }
+        },
+        "cssnano-preset-default": {
+            "version": "4.0.7",
+            "resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-4.0.7.tgz",
+            "integrity": "sha512-x0YHHx2h6p0fCl1zY9L9roD7rnlltugGu7zXSKQx6k2rYw0Hi3IqxcoAGF7u9Q5w1nt7vK0ulxV8Lo+EvllGsA==",
+            "dev": true,
+            "requires": {
+                "css-declaration-sorter": "4.0.1",
+                "cssnano-util-raw-cache": "4.0.1",
+                "postcss": "7.0.17",
+                "postcss-calc": "7.0.1",
+                "postcss-colormin": "4.0.3",
+                "postcss-convert-values": "4.0.1",
+                "postcss-discard-comments": "4.0.2",
+                "postcss-discard-duplicates": "4.0.2",
+                "postcss-discard-empty": "4.0.1",
+                "postcss-discard-overridden": "4.0.1",
+                "postcss-merge-longhand": "4.0.11",
+                "postcss-merge-rules": "4.0.3",
+                "postcss-minify-font-values": "4.0.2",
+                "postcss-minify-gradients": "4.0.2",
+                "postcss-minify-params": "4.0.2",
+                "postcss-minify-selectors": "4.0.2",
+                "postcss-normalize-charset": "4.0.1",
+                "postcss-normalize-display-values": "4.0.2",
+                "postcss-normalize-positions": "4.0.2",
+                "postcss-normalize-repeat-style": "4.0.2",
+                "postcss-normalize-string": "4.0.2",
+                "postcss-normalize-timing-functions": "4.0.2",
+                "postcss-normalize-unicode": "4.0.1",
+                "postcss-normalize-url": "4.0.1",
+                "postcss-normalize-whitespace": "4.0.2",
+                "postcss-ordered-values": "4.1.2",
+                "postcss-reduce-initial": "4.0.3",
+                "postcss-reduce-transforms": "4.0.2",
+                "postcss-svgo": "4.0.2",
+                "postcss-unique-selectors": "4.0.1"
+            }
+        },
+        "cssnano-util-get-arguments": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/cssnano-util-get-arguments/-/cssnano-util-get-arguments-4.0.0.tgz",
+            "integrity": "sha1-7ToIKZ8h11dBsg87gfGU7UnMFQ8=",
+            "dev": true
+        },
+        "cssnano-util-get-match": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/cssnano-util-get-match/-/cssnano-util-get-match-4.0.0.tgz",
+            "integrity": "sha1-wOTKB/U4a7F+xeUiULT1lhNlFW0=",
+            "dev": true
+        },
+        "cssnano-util-raw-cache": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/cssnano-util-raw-cache/-/cssnano-util-raw-cache-4.0.1.tgz",
+            "integrity": "sha512-qLuYtWK2b2Dy55I8ZX3ky1Z16WYsx544Q0UWViebptpwn/xDBmog2TLg4f+DBMg1rJ6JDWtn96WHbOKDWt1WQA==",
+            "dev": true,
+            "requires": {
+                "postcss": "7.0.17"
+            }
+        },
+        "cssnano-util-same-parent": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/cssnano-util-same-parent/-/cssnano-util-same-parent-4.0.1.tgz",
+            "integrity": "sha512-WcKx5OY+KoSIAxBW6UBBRay1U6vkYheCdjyVNDm85zt5K9mHoGOfsOsqIszfAqrQQFIIKgjh2+FDgIj/zsl21Q==",
+            "dev": true
+        },
+        "csso": {
+            "version": "3.5.1",
+            "resolved": "https://registry.npmjs.org/csso/-/csso-3.5.1.tgz",
+            "integrity": "sha512-vrqULLffYU1Q2tLdJvaCYbONStnfkfimRxXNaGjxMldI0C7JPBC4rB1RyjhfdZ4m1frm8pM9uRPKH3d2knZ8gg==",
+            "dev": true,
+            "requires": {
+                "css-tree": "1.0.0-alpha.29"
+            },
+            "dependencies": {
+                "css-tree": {
+                    "version": "1.0.0-alpha.29",
+                    "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.0.0-alpha.29.tgz",
+                    "integrity": "sha512-sRNb1XydwkW9IOci6iB2xmy8IGCj6r/fr+JWitvJ2JxQRPzN3T4AGGVWCMlVmVwM1gtgALJRmGIlWv5ppnGGkg==",
+                    "dev": true,
+                    "requires": {
+                        "mdn-data": "1.1.4",
+                        "source-map": "0.5.7"
+                    }
+                },
+                "mdn-data": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-1.1.4.tgz",
+                    "integrity": "sha512-FSYbp3lyKjyj3E7fMl6rYvUdX0FBXaluGqlFoYESWQlyUTq8R+wp0rkFxoYFqZlHCvsUXGjyJmLQSnXToYhOSA==",
+                    "dev": true
+                },
+                "source-map": {
+                    "version": "0.5.7",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+                    "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+                    "dev": true
+                }
+            }
+        },
+        "currently-unhandled": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
+            "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
+            "dev": true,
+            "requires": {
+                "array-find-index": "1.0.2"
+            }
+        },
+        "cyclist": {
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-0.2.2.tgz",
+            "integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA=",
+            "dev": true
+        },
+        "damerau-levenshtein": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.5.tgz",
+            "integrity": "sha512-CBCRqFnpu715iPmw1KrdOrzRqbdFwQTwAWyyyYS42+iAgHCuXZ+/TdMgQkUENPomxEz9z1BEzuQU2Xw0kUuAgA==",
+            "dev": true
+        },
+        "date-now": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
+            "integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs=",
+            "dev": true
+        },
+        "debug": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+            "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+            "dev": true,
+            "requires": {
+                "ms": "2.1.2"
+            }
+        },
+        "decamelize": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+            "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+            "dev": true
+        },
+        "decamelize-keys": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
+            "integrity": "sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=",
+            "dev": true,
+            "requires": {
+                "decamelize": "1.2.0",
+                "map-obj": "1.0.1"
+            },
+            "dependencies": {
+                "map-obj": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+                    "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
+                    "dev": true
+                }
+            }
+        },
+        "decode-uri-component": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+            "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+            "dev": true
+        },
+        "deep-equal": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+            "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
+            "dev": true
+        },
+        "deep-extend": {
+            "version": "0.5.1",
+            "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.5.1.tgz",
+            "integrity": "sha512-N8vBdOa+DF7zkRrDCsaOXoCs/E2fJfx9B9MrKnnSiHNh4ws7eSys6YQE4KvT1cecKmOASYQBhbKjeuDD9lT81w==",
+            "dev": true
+        },
+        "deep-is": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+            "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+            "dev": true
+        },
+        "default-gateway": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/default-gateway/-/default-gateway-4.2.0.tgz",
+            "integrity": "sha512-h6sMrVB1VMWVrW13mSc6ia/DwYYw5MN6+exNu1OaJeFac5aSAvwM7lZ0NVfTABuSkQelr4h5oebg3KB1XPdjgA==",
+            "dev": true,
+            "requires": {
+                "execa": "1.0.0",
+                "ip-regex": "2.1.0"
+            }
+        },
+        "define-properties": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+            "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+            "dev": true,
+            "requires": {
+                "object-keys": "1.1.1"
+            }
+        },
+        "define-property": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
+            "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
+            "dev": true,
+            "requires": {
+                "is-descriptor": "1.0.2",
+                "isobject": "3.0.1"
+            },
+            "dependencies": {
+                "is-accessor-descriptor": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+                    "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "6.0.2"
+                    }
+                },
+                "is-data-descriptor": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+                    "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "6.0.2"
+                    }
+                },
+                "is-descriptor": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+                    "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+                    "dev": true,
+                    "requires": {
+                        "is-accessor-descriptor": "1.0.0",
+                        "is-data-descriptor": "1.0.0",
+                        "kind-of": "6.0.2"
+                    }
+                }
+            }
+        },
+        "del": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/del/-/del-4.1.1.tgz",
+            "integrity": "sha512-QwGuEUouP2kVwQenAsOof5Fv8K9t3D8Ca8NxcXKrIpEHjTXK5J2nXLdP+ALI1cgv8wj7KuwBhTwBkOZSJKM5XQ==",
+            "dev": true,
+            "requires": {
+                "@types/glob": "7.1.1",
+                "globby": "6.1.0",
+                "is-path-cwd": "2.2.0",
+                "is-path-in-cwd": "2.1.0",
+                "p-map": "2.1.0",
+                "pify": "4.0.1",
+                "rimraf": "2.6.3"
+            },
+            "dependencies": {
+                "globby": {
+                    "version": "6.1.0",
+                    "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
+                    "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
+                    "dev": true,
+                    "requires": {
+                        "array-union": "1.0.2",
+                        "glob": "7.1.4",
+                        "object-assign": "4.1.1",
+                        "pify": "2.3.0",
+                        "pinkie-promise": "2.0.1"
+                    },
+                    "dependencies": {
+                        "pify": {
+                            "version": "2.3.0",
+                            "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+                            "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+                            "dev": true
+                        }
+                    }
+                }
+            }
+        },
+        "depd": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+            "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
+            "dev": true
+        },
+        "des.js": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz",
+            "integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
+            "dev": true,
+            "requires": {
+                "inherits": "2.0.4",
+                "minimalistic-assert": "1.0.1"
+            }
+        },
+        "destroy": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+            "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
+            "dev": true
+        },
+        "detect-file": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz",
+            "integrity": "sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc=",
+            "dev": true
+        },
+        "detect-node": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.0.4.tgz",
+            "integrity": "sha512-ZIzRpLJrOj7jjP2miAtgqIfmzbxa4ZOr5jJc601zklsfEx9oTzmmj2nVpIPRpNlRTIh8lc1kyViIY7BWSGNmKw==",
+            "dev": true
+        },
+        "diffie-hellman": {
+            "version": "5.0.3",
+            "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+            "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
+            "dev": true,
+            "requires": {
+                "bn.js": "4.11.8",
+                "miller-rabin": "4.0.1",
+                "randombytes": "2.1.0"
+            }
+        },
+        "dir-glob": {
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.2.2.tgz",
+            "integrity": "sha512-f9LBi5QWzIW3I6e//uxZoLBlUt9kcp66qo0sSCxL6YZKc75R1c4MFCoe/LaZiBGmgujvQdxc5Bn3QhfyvK5Hsw==",
+            "dev": true,
+            "requires": {
+                "path-type": "3.0.0"
+            },
+            "dependencies": {
+                "path-type": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+                    "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+                    "dev": true,
+                    "requires": {
+                        "pify": "3.0.0"
+                    }
+                },
+                "pify": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+                    "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+                    "dev": true
+                }
+            }
+        },
+        "dns-equal": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/dns-equal/-/dns-equal-1.0.0.tgz",
+            "integrity": "sha1-s55/HabrCnW6nBcySzR1PEfgZU0=",
+            "dev": true
+        },
+        "dns-packet": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-1.3.1.tgz",
+            "integrity": "sha512-0UxfQkMhYAUaZI+xrNZOz/as5KgDU0M/fQ9b6SpkyLbk3GEswDi6PADJVaYJradtRVsRIlF1zLyOodbcTCDzUg==",
+            "dev": true,
+            "requires": {
+                "ip": "1.1.5",
+                "safe-buffer": "5.1.2"
+            }
+        },
+        "dns-txt": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/dns-txt/-/dns-txt-2.0.2.tgz",
+            "integrity": "sha1-uR2Ab10nGI5Ks+fRB9iBocxGQrY=",
+            "dev": true,
+            "requires": {
+                "buffer-indexof": "1.1.1"
+            }
+        },
+        "doctrine": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+            "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+            "dev": true,
+            "requires": {
+                "esutils": "2.0.2"
+            }
+        },
+        "dom-converter": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/dom-converter/-/dom-converter-0.2.0.tgz",
+            "integrity": "sha512-gd3ypIPfOMr9h5jIKq8E3sHOTCjeirnl0WK5ZdS1AW0Odt0b1PaWaHdJ4Qk4klv+YB9aJBS7mESXjFoDQPu6DA==",
+            "dev": true,
+            "requires": {
+                "utila": "0.4.0"
+            }
+        },
+        "dom-serializer": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.1.tgz",
+            "integrity": "sha512-l0IU0pPzLWSHBcieZbpOKgkIn3ts3vAh7ZuFyXNwJxJXk/c4Gwj9xaTJwIDVQCXawWD0qb3IzMGH5rglQaO0XA==",
+            "dev": true,
+            "requires": {
+                "domelementtype": "1.3.1",
+                "entities": "1.1.2"
+            }
+        },
+        "dom-walk": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.1.tgz",
+            "integrity": "sha1-ZyIm3HTI95mtNTB9+TaroRrNYBg="
+        },
+        "domain-browser": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
+            "integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA==",
+            "dev": true
+        },
+        "domelementtype": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
+            "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==",
+            "dev": true
+        },
+        "domhandler": {
+            "version": "2.4.2",
+            "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
+            "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
+            "dev": true,
+            "requires": {
+                "domelementtype": "1.3.1"
+            }
+        },
+        "domutils": {
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.7.0.tgz",
+            "integrity": "sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==",
+            "dev": true,
+            "requires": {
+                "dom-serializer": "0.1.1",
+                "domelementtype": "1.3.1"
+            }
+        },
+        "dot-prop": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
+            "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
+            "dev": true,
+            "requires": {
+                "is-obj": "1.0.1"
+            }
+        },
+        "duplexify": {
+            "version": "3.7.1",
+            "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
+            "integrity": "sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==",
+            "dev": true,
+            "requires": {
+                "end-of-stream": "1.4.1",
+                "inherits": "2.0.4",
+                "readable-stream": "2.3.6",
+                "stream-shift": "1.0.0"
+            },
+            "dependencies": {
+                "isarray": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                    "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+                    "dev": true
+                },
+                "readable-stream": {
+                    "version": "2.3.6",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+                    "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+                    "dev": true,
+                    "requires": {
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.4",
+                        "isarray": "1.0.0",
+                        "process-nextick-args": "2.0.1",
+                        "safe-buffer": "5.1.2",
+                        "string_decoder": "1.1.1",
+                        "util-deprecate": "1.0.2"
+                    }
+                },
+                "string_decoder": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+                    "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+                    "dev": true,
+                    "requires": {
+                        "safe-buffer": "5.1.2"
+                    }
+                }
+            }
+        },
+        "ee-first": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+            "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
+            "dev": true
+        },
+        "ejs": {
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/ejs/-/ejs-2.6.2.tgz",
+            "integrity": "sha512-PcW2a0tyTuPHz3tWyYqtK6r1fZ3gp+3Sop8Ph+ZYN81Ob5rwmbHEzaqs10N3BEsaGTkh/ooniXK+WwszGlc2+Q==",
+            "dev": true
+        },
+        "electron-to-chromium": {
+            "version": "1.3.199",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.199.tgz",
+            "integrity": "sha512-gachlDdHSK47s0N2e58GH9HMC6Z4ip0SfmYUa5iEbE50AKaOUXysaJnXMfKj0xB245jWbYcyFSH+th3rqsF8hA==",
+            "dev": true
+        },
+        "elliptic": {
+            "version": "6.5.0",
+            "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.0.tgz",
+            "integrity": "sha512-eFOJTMyCYb7xtE/caJ6JJu+bhi67WCYNbkGSknu20pmM8Ke/bqOfdnZWxyoGN26JgfxTbXrsCkEw4KheCT/KGg==",
+            "dev": true,
+            "requires": {
+                "bn.js": "4.11.8",
+                "brorand": "1.1.0",
+                "hash.js": "1.1.7",
+                "hmac-drbg": "1.0.1",
+                "inherits": "2.0.4",
+                "minimalistic-assert": "1.0.1",
+                "minimalistic-crypto-utils": "1.0.1"
+            }
+        },
+        "emoji-regex": {
+            "version": "7.0.3",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+            "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+            "dev": true
+        },
+        "emojis-list": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
+            "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k="
+        },
+        "encodeurl": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+            "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
+            "dev": true
+        },
+        "end-of-stream": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
+            "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+            "dev": true,
+            "requires": {
+                "once": "1.4.0"
+            }
+        },
+        "enhanced-resolve": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.1.0.tgz",
+            "integrity": "sha512-F/7vkyTtyc/llOIn8oWclcB25KdRaiPBpZYDgJHgh/UHtpgT2p2eldQgtQnLtUvfMKPKxbRaQM/hHkvLHt1Vng==",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "4.2.0",
+                "memory-fs": "0.4.1",
+                "tapable": "1.1.3"
+            }
+        },
+        "entities": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
+            "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==",
+            "dev": true
+        },
+        "errno": {
+            "version": "0.1.7",
+            "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
+            "integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
+            "dev": true,
+            "requires": {
+                "prr": "1.0.1"
+            }
+        },
+        "error-ex": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+            "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+            "dev": true,
+            "requires": {
+                "is-arrayish": "0.2.1"
+            }
+        },
+        "es-abstract": {
+            "version": "1.13.0",
+            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.13.0.tgz",
+            "integrity": "sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==",
+            "dev": true,
+            "requires": {
+                "es-to-primitive": "1.2.0",
+                "function-bind": "1.1.1",
+                "has": "1.0.3",
+                "is-callable": "1.1.4",
+                "is-regex": "1.0.4",
+                "object-keys": "1.1.1"
+            }
+        },
+        "es-to-primitive": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
+            "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
+            "dev": true,
+            "requires": {
+                "is-callable": "1.1.4",
+                "is-date-object": "1.0.1",
+                "is-symbol": "1.0.2"
+            }
+        },
+        "es6-templates": {
+            "version": "0.2.3",
+            "resolved": "https://registry.npmjs.org/es6-templates/-/es6-templates-0.2.3.tgz",
+            "integrity": "sha1-XLmsn7He1usSOTQrgdeSu7QHjuQ=",
+            "dev": true,
+            "requires": {
+                "recast": "0.11.23",
+                "through": "2.3.8"
+            }
+        },
+        "escape-html": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+            "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
+            "dev": true
+        },
+        "escape-string-regexp": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+            "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+            "dev": true
+        },
+        "eslint": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-6.1.0.tgz",
+            "integrity": "sha512-QhrbdRD7ofuV09IuE2ySWBz0FyXCq0rriLTZXZqaWSI79CVtHVRdkFuFTViiqzZhkCgfOh9USpriuGN2gIpZDQ==",
+            "dev": true,
+            "requires": {
+                "@babel/code-frame": "7.5.5",
+                "ajv": "6.10.2",
+                "chalk": "2.4.2",
+                "cross-spawn": "6.0.5",
+                "debug": "4.1.1",
+                "doctrine": "3.0.0",
+                "eslint-scope": "5.0.0",
+                "eslint-utils": "1.4.0",
+                "eslint-visitor-keys": "1.0.0",
+                "espree": "6.0.0",
+                "esquery": "1.0.1",
+                "esutils": "2.0.2",
+                "file-entry-cache": "5.0.1",
+                "functional-red-black-tree": "1.0.1",
+                "glob-parent": "5.0.0",
+                "globals": "11.12.0",
+                "ignore": "4.0.6",
+                "import-fresh": "3.1.0",
+                "imurmurhash": "0.1.4",
+                "inquirer": "6.5.0",
+                "is-glob": "4.0.1",
+                "js-yaml": "3.13.1",
+                "json-stable-stringify-without-jsonify": "1.0.1",
+                "levn": "0.3.0",
+                "lodash": "4.17.15",
+                "minimatch": "3.0.4",
+                "mkdirp": "0.5.1",
+                "natural-compare": "1.4.0",
+                "optionator": "0.8.2",
+                "progress": "2.0.3",
+                "regexpp": "2.0.1",
+                "semver": "6.3.0",
+                "strip-ansi": "5.2.0",
+                "strip-json-comments": "3.0.1",
+                "table": "5.4.4",
+                "text-table": "0.2.0",
+                "v8-compile-cache": "2.0.3"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+                    "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+                    "dev": true
+                },
+                "eslint-scope": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.0.0.tgz",
+                    "integrity": "sha512-oYrhJW7S0bxAFDvWqzvMPRm6pcgcnWc4QnofCAqRTRfQC0JcwenzGglTtsLyIuuWFfkqDG9vz67cnttSd53djw==",
+                    "dev": true,
+                    "requires": {
+                        "esrecurse": "4.2.1",
+                        "estraverse": "4.2.0"
+                    }
+                },
+                "glob-parent": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.0.0.tgz",
+                    "integrity": "sha512-Z2RwiujPRGluePM6j699ktJYxmPpJKCfpGA13jz2hmFZC7gKetzrWvg5KN3+OsIFmydGyZ1AVwERCq1w/ZZwRg==",
+                    "dev": true,
+                    "requires": {
+                        "is-glob": "4.0.1"
+                    }
+                },
+                "import-fresh": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.1.0.tgz",
+                    "integrity": "sha512-PpuksHKGt8rXfWEr9m9EHIpgyyaltBy8+eF6GJM0QCAxMgxCfucMF3mjecK2QsJr0amJW7gTqh5/wht0z2UhEQ==",
+                    "dev": true,
+                    "requires": {
+                        "parent-module": "1.0.1",
+                        "resolve-from": "4.0.0"
+                    }
+                },
+                "resolve-from": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+                    "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+                    "dev": true
+                },
+                "semver": {
+                    "version": "6.3.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+                    "dev": true
+                },
+                "strip-ansi": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+                    "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "4.1.0"
+                    }
+                }
+            }
+        },
+        "eslint-config-airbnb": {
+            "version": "17.1.1",
+            "resolved": "https://registry.npmjs.org/eslint-config-airbnb/-/eslint-config-airbnb-17.1.1.tgz",
+            "integrity": "sha512-xCu//8a/aWqagKljt+1/qAM62BYZeNq04HmdevG5yUGWpja0I/xhqd6GdLRch5oetEGFiJAnvtGuTEAese53Qg==",
+            "dev": true,
+            "requires": {
+                "eslint-config-airbnb-base": "13.2.0",
+                "object.assign": "4.1.0",
+                "object.entries": "1.1.0"
+            }
+        },
+        "eslint-config-airbnb-base": {
+            "version": "13.2.0",
+            "resolved": "https://registry.npmjs.org/eslint-config-airbnb-base/-/eslint-config-airbnb-base-13.2.0.tgz",
+            "integrity": "sha512-1mg/7eoB4AUeB0X1c/ho4vb2gYkNH8Trr/EgCT/aGmKhhG+F6vF5s8+iRBlWAzFIAphxIdp3YfEKgEl0f9Xg+w==",
+            "dev": true,
+            "requires": {
+                "confusing-browser-globals": "1.0.7",
+                "object.assign": "4.1.0",
+                "object.entries": "1.1.0"
+            }
+        },
+        "eslint-import-resolver-node": {
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.2.tgz",
+            "integrity": "sha512-sfmTqJfPSizWu4aymbPr4Iidp5yKm8yDkHp+Ir3YiTHiiDfxh69mOUsmiqW6RZ9zRXFaF64GtYmN7e+8GHBv6Q==",
+            "dev": true,
+            "requires": {
+                "debug": "2.6.9",
+                "resolve": "1.11.1"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "2.6.9",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+                    "dev": true
+                }
+            }
+        },
+        "eslint-loader": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/eslint-loader/-/eslint-loader-2.2.1.tgz",
+            "integrity": "sha512-RLgV9hoCVsMLvOxCuNjdqOrUqIj9oJg8hF44vzJaYqsAHuY9G2YAeN3joQ9nxP0p5Th9iFSIpKo+SD8KISxXRg==",
+            "dev": true,
+            "requires": {
+                "loader-fs-cache": "1.0.2",
+                "loader-utils": "1.2.3",
+                "object-assign": "4.1.1",
+                "object-hash": "1.3.1",
+                "rimraf": "2.6.3"
+            }
+        },
+        "eslint-module-utils": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.4.1.tgz",
+            "integrity": "sha512-H6DOj+ejw7Tesdgbfs4jeS4YMFrT8uI8xwd1gtQqXssaR0EQ26L+2O/w6wkYFy2MymON0fTwHmXBvvfLNZVZEw==",
+            "dev": true,
+            "requires": {
+                "debug": "2.6.9",
+                "pkg-dir": "2.0.0"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "2.6.9",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
+                "find-up": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+                    "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+                    "dev": true,
+                    "requires": {
+                        "locate-path": "2.0.0"
+                    }
+                },
+                "locate-path": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+                    "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+                    "dev": true,
+                    "requires": {
+                        "p-locate": "2.0.0",
+                        "path-exists": "3.0.0"
+                    }
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+                    "dev": true
+                },
+                "p-limit": {
+                    "version": "1.3.0",
+                    "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+                    "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+                    "dev": true,
+                    "requires": {
+                        "p-try": "1.0.0"
+                    }
+                },
+                "p-locate": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+                    "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+                    "dev": true,
+                    "requires": {
+                        "p-limit": "1.3.0"
+                    }
+                },
+                "p-try": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+                    "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+                    "dev": true
+                },
+                "pkg-dir": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
+                    "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
+                    "dev": true,
+                    "requires": {
+                        "find-up": "2.1.0"
+                    }
+                }
+            }
+        },
+        "eslint-plugin-import": {
+            "version": "2.18.2",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.18.2.tgz",
+            "integrity": "sha512-5ohpsHAiUBRNaBWAF08izwUGlbrJoJJ+W9/TBwsGoR1MnlgfwMIKrFeSjWbt6moabiXW9xNvtFz+97KHRfI4HQ==",
+            "dev": true,
+            "requires": {
+                "array-includes": "3.0.3",
+                "contains-path": "0.1.0",
+                "debug": "2.6.9",
+                "doctrine": "1.5.0",
+                "eslint-import-resolver-node": "0.3.2",
+                "eslint-module-utils": "2.4.1",
+                "has": "1.0.3",
+                "minimatch": "3.0.4",
+                "object.values": "1.1.0",
+                "read-pkg-up": "2.0.0",
+                "resolve": "1.11.1"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "2.6.9",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
+                "doctrine": {
+                    "version": "1.5.0",
+                    "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
+                    "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
+                    "dev": true,
+                    "requires": {
+                        "esutils": "2.0.2",
+                        "isarray": "1.0.0"
+                    }
+                },
+                "isarray": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                    "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+                    "dev": true
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+                    "dev": true
+                }
+            }
+        },
+        "eslint-plugin-jsx-a11y": {
+            "version": "6.2.3",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.2.3.tgz",
+            "integrity": "sha512-CawzfGt9w83tyuVekn0GDPU9ytYtxyxyFZ3aSWROmnRRFQFT2BiPJd7jvRdzNDi6oLWaS2asMeYSNMjWTV4eNg==",
+            "dev": true,
+            "requires": {
+                "@babel/runtime": "7.5.5",
+                "aria-query": "3.0.0",
+                "array-includes": "3.0.3",
+                "ast-types-flow": "0.0.7",
+                "axobject-query": "2.0.2",
+                "damerau-levenshtein": "1.0.5",
+                "emoji-regex": "7.0.3",
+                "has": "1.0.3",
+                "jsx-ast-utils": "2.2.1"
+            }
+        },
+        "eslint-plugin-react": {
+            "version": "7.14.3",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.14.3.tgz",
+            "integrity": "sha512-EzdyyBWC4Uz2hPYBiEJrKCUi2Fn+BJ9B/pJQcjw5X+x/H2Nm59S4MJIvL4O5NEE0+WbnQwEBxWY03oUk+Bc3FA==",
+            "dev": true,
+            "requires": {
+                "array-includes": "3.0.3",
+                "doctrine": "2.1.0",
+                "has": "1.0.3",
+                "jsx-ast-utils": "2.2.1",
+                "object.entries": "1.1.0",
+                "object.fromentries": "2.0.0",
+                "object.values": "1.1.0",
+                "prop-types": "15.7.2",
+                "resolve": "1.11.1"
+            },
+            "dependencies": {
+                "doctrine": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+                    "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+                    "dev": true,
+                    "requires": {
+                        "esutils": "2.0.2"
+                    }
+                }
+            }
+        },
+        "eslint-scope": {
+            "version": "3.7.1",
+            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.1.tgz",
+            "integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
+            "dev": true,
+            "requires": {
+                "esrecurse": "4.2.1",
+                "estraverse": "4.2.0"
+            }
+        },
+        "eslint-utils": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.0.tgz",
+            "integrity": "sha512-7ehnzPaP5IIEh1r1tkjuIrxqhNkzUJa9z3R92tLJdZIVdWaczEhr3EbhGtsMrVxi1KeR8qA7Off6SWc5WNQqyQ==",
+            "dev": true,
+            "requires": {
+                "eslint-visitor-keys": "1.0.0"
+            }
+        },
+        "eslint-visitor-keys": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
+            "integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==",
+            "dev": true
+        },
+        "espree": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/espree/-/espree-6.0.0.tgz",
+            "integrity": "sha512-lJvCS6YbCn3ImT3yKkPe0+tJ+mH6ljhGNjHQH9mRtiO6gjhVAOhVXW1yjnwqGwTkK3bGbye+hb00nFNmu0l/1Q==",
+            "dev": true,
+            "requires": {
+                "acorn": "6.2.1",
+                "acorn-jsx": "5.0.1",
+                "eslint-visitor-keys": "1.0.0"
+            }
+        },
+        "esprima": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+            "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+            "dev": true
+        },
+        "esquery": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.1.tgz",
+            "integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
+            "dev": true,
+            "requires": {
+                "estraverse": "4.2.0"
+            }
+        },
+        "esrecurse": {
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
+            "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
+            "dev": true,
+            "requires": {
+                "estraverse": "4.2.0"
+            }
+        },
+        "estraverse": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+            "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+            "dev": true
+        },
+        "esutils": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+            "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+            "dev": true
+        },
+        "etag": {
+            "version": "1.8.1",
+            "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+            "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
+            "dev": true
+        },
+        "eventemitter3": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
+            "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==",
+            "dev": true
+        },
+        "events": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/events/-/events-3.0.0.tgz",
+            "integrity": "sha512-Dc381HFWJzEOhQ+d8pkNon++bk9h6cdAoAj4iE6Q4y6xgTzySWXlKn05/TVNpjnfRqi/X0EpJEJohPjNI3zpVA==",
+            "dev": true
+        },
+        "eventsource": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-1.0.7.tgz",
+            "integrity": "sha512-4Ln17+vVT0k8aWq+t/bF5arcS3EpT9gYtW66EPacdj/mAFevznsnyoHLPy2BA8gbIQeIHoPsvwmfBftfcG//BQ==",
+            "dev": true,
+            "requires": {
+                "original": "1.0.2"
+            }
+        },
+        "evp_bytestokey": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
+            "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
+            "dev": true,
+            "requires": {
+                "md5.js": "1.3.5",
+                "safe-buffer": "5.1.2"
+            }
+        },
+        "execa": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+            "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+            "dev": true,
+            "requires": {
+                "cross-spawn": "6.0.5",
+                "get-stream": "4.1.0",
+                "is-stream": "1.1.0",
+                "npm-run-path": "2.0.2",
+                "p-finally": "1.0.0",
+                "signal-exit": "3.0.2",
+                "strip-eof": "1.0.0"
+            }
+        },
+        "execall": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/execall/-/execall-2.0.0.tgz",
+            "integrity": "sha512-0FU2hZ5Hh6iQnarpRtQurM/aAvp3RIbfvgLHrcqJYzhXyV2KFruhuChf9NC6waAhiUR7FFtlugkI4p7f2Fqlow==",
+            "dev": true,
+            "requires": {
+                "clone-regexp": "2.2.0"
+            }
+        },
+        "expand-brackets": {
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+            "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+            "dev": true,
+            "requires": {
+                "debug": "2.6.9",
+                "define-property": "0.2.5",
+                "extend-shallow": "2.0.1",
+                "posix-character-classes": "0.1.1",
+                "regex-not": "1.0.2",
+                "snapdragon": "0.8.2",
+                "to-regex": "3.0.2"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "2.6.9",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
+                "define-property": {
+                    "version": "0.2.5",
+                    "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+                    "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+                    "dev": true,
+                    "requires": {
+                        "is-descriptor": "0.1.6"
+                    }
+                },
+                "extend-shallow": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                    "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                    "dev": true,
+                    "requires": {
+                        "is-extendable": "0.1.1"
+                    }
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+                    "dev": true
+                }
+            }
+        },
+        "expand-tilde": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
+            "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
+            "dev": true,
+            "requires": {
+                "homedir-polyfill": "1.0.3"
+            }
+        },
+        "express": {
+            "version": "4.17.1",
+            "resolved": "https://registry.npmjs.org/express/-/express-4.17.1.tgz",
+            "integrity": "sha512-mHJ9O79RqluphRrcw2X/GTh3k9tVv8YcoyY4Kkh4WDMUYKRZUq0h1o0w2rrrxBqM7VoeUVqgb27xlEMXTnYt4g==",
+            "dev": true,
+            "requires": {
+                "accepts": "1.3.7",
+                "array-flatten": "1.1.1",
+                "body-parser": "1.19.0",
+                "content-disposition": "0.5.3",
+                "content-type": "1.0.4",
+                "cookie": "0.4.0",
+                "cookie-signature": "1.0.6",
+                "debug": "2.6.9",
+                "depd": "1.1.2",
+                "encodeurl": "1.0.2",
+                "escape-html": "1.0.3",
+                "etag": "1.8.1",
+                "finalhandler": "1.1.2",
+                "fresh": "0.5.2",
+                "merge-descriptors": "1.0.1",
+                "methods": "1.1.2",
+                "on-finished": "2.3.0",
+                "parseurl": "1.3.3",
+                "path-to-regexp": "0.1.7",
+                "proxy-addr": "2.0.5",
+                "qs": "6.7.0",
+                "range-parser": "1.2.1",
+                "safe-buffer": "5.1.2",
+                "send": "0.17.1",
+                "serve-static": "1.14.1",
+                "setprototypeof": "1.1.1",
+                "statuses": "1.5.0",
+                "type-is": "1.6.18",
+                "utils-merge": "1.0.1",
+                "vary": "1.1.2"
+            },
+            "dependencies": {
+                "array-flatten": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+                    "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
+                    "dev": true
+                },
+                "debug": {
+                    "version": "2.6.9",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+                    "dev": true
+                },
+                "path-to-regexp": {
+                    "version": "0.1.7",
+                    "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+                    "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
+                    "dev": true
+                }
+            }
+        },
+        "extend": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+            "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+            "dev": true
+        },
+        "extend-shallow": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+            "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+            "dev": true,
+            "requires": {
+                "assign-symbols": "1.0.0",
+                "is-extendable": "1.0.1"
+            },
+            "dependencies": {
+                "is-extendable": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+                    "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+                    "dev": true,
+                    "requires": {
+                        "is-plain-object": "2.0.4"
+                    }
+                }
+            }
+        },
+        "external-editor": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
+            "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
+            "dev": true,
+            "requires": {
+                "chardet": "0.7.0",
+                "iconv-lite": "0.4.24",
+                "tmp": "0.0.33"
+            }
+        },
+        "extglob": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+            "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+            "dev": true,
+            "requires": {
+                "array-unique": "0.3.2",
+                "define-property": "1.0.0",
+                "expand-brackets": "2.1.4",
+                "extend-shallow": "2.0.1",
+                "fragment-cache": "0.2.1",
+                "regex-not": "1.0.2",
+                "snapdragon": "0.8.2",
+                "to-regex": "3.0.2"
+            },
+            "dependencies": {
+                "define-property": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+                    "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+                    "dev": true,
+                    "requires": {
+                        "is-descriptor": "1.0.2"
+                    }
+                },
+                "extend-shallow": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                    "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                    "dev": true,
+                    "requires": {
+                        "is-extendable": "0.1.1"
+                    }
+                },
+                "is-accessor-descriptor": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+                    "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "6.0.2"
+                    }
+                },
+                "is-data-descriptor": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+                    "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "6.0.2"
+                    }
+                },
+                "is-descriptor": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+                    "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+                    "dev": true,
+                    "requires": {
+                        "is-accessor-descriptor": "1.0.0",
+                        "is-data-descriptor": "1.0.0",
+                        "kind-of": "6.0.2"
+                    }
+                }
+            }
+        },
+        "fast-deep-equal": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+            "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+            "dev": true
+        },
+        "fast-glob": {
+            "version": "2.2.7",
+            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-2.2.7.tgz",
+            "integrity": "sha512-g1KuQwHOZAmOZMuBtHdxDtju+T2RT8jgCC9aANsbpdiDDTSnjgfuVsIBNKbUeJI3oKMRExcfNDtJl4OhbffMsw==",
+            "dev": true,
+            "requires": {
+                "@mrmlnc/readdir-enhanced": "2.2.1",
+                "@nodelib/fs.stat": "1.1.3",
+                "glob-parent": "3.1.0",
+                "is-glob": "4.0.1",
+                "merge2": "1.2.3",
+                "micromatch": "3.1.10"
+            }
+        },
+        "fast-json-stable-stringify": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+            "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+            "dev": true
+        },
+        "fast-levenshtein": {
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+            "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
+        },
+        "fastparse": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/fastparse/-/fastparse-1.1.2.tgz",
+            "integrity": "sha512-483XLLxTVIwWK3QTrMGRqUfUpoOs/0hbQrl2oz4J0pAcm3A3bu84wxTFqGqkJzewCLdME38xJLJAxBABfQT8sQ==",
+            "dev": true
+        },
+        "faye-websocket": {
+            "version": "0.10.0",
+            "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.10.0.tgz",
+            "integrity": "sha1-TkkvjQTftviQA1B/btvy1QHnxvQ=",
+            "dev": true,
+            "requires": {
+                "websocket-driver": "0.7.3"
+            }
+        },
+        "figgy-pudding": {
+            "version": "3.5.1",
+            "resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.1.tgz",
+            "integrity": "sha512-vNKxJHTEKNThjfrdJwHc7brvM6eVevuO5nTj6ez8ZQ1qbXTvGthucRF7S4vf2cr71QVnT70V34v0S1DyQsti0w==",
+            "dev": true
+        },
+        "figures": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+            "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+            "dev": true,
+            "requires": {
+                "escape-string-regexp": "1.0.5"
+            }
+        },
+        "file-entry-cache": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
+            "integrity": "sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==",
+            "dev": true,
+            "requires": {
+                "flat-cache": "2.0.1"
+            }
+        },
+        "file-loader": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/file-loader/-/file-loader-4.1.0.tgz",
+            "integrity": "sha512-ajDk1nlByoalZAGR4b0H6oD+EGlWnyW1qbSxzaUc7RFiqmn+RbXQQRbTc72jsiUIlVusJ4Et58ltds8ZwTfnAw==",
+            "dev": true,
+            "requires": {
+                "loader-utils": "1.2.3",
+                "schema-utils": "2.0.1"
+            },
+            "dependencies": {
+                "schema-utils": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.0.1.tgz",
+                    "integrity": "sha512-HJFKJ4JixDpRur06QHwi8uu2kZbng318ahWEKgBjc0ZklcE4FDvmm2wghb448q0IRaABxIESt8vqPFvwgMB80A==",
+                    "dev": true,
+                    "requires": {
+                        "ajv": "6.10.2",
+                        "ajv-keywords": "3.4.1"
+                    }
+                }
+            }
+        },
+        "fill-range": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+            "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+            "dev": true,
+            "requires": {
+                "extend-shallow": "2.0.1",
+                "is-number": "3.0.0",
+                "repeat-string": "1.6.1",
+                "to-regex-range": "2.1.1"
+            },
+            "dependencies": {
+                "extend-shallow": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                    "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                    "dev": true,
+                    "requires": {
+                        "is-extendable": "0.1.1"
+                    }
+                }
+            }
+        },
+        "finalhandler": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
+            "integrity": "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==",
+            "dev": true,
+            "requires": {
+                "debug": "2.6.9",
+                "encodeurl": "1.0.2",
+                "escape-html": "1.0.3",
+                "on-finished": "2.3.0",
+                "parseurl": "1.3.3",
+                "statuses": "1.5.0",
+                "unpipe": "1.0.0"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "2.6.9",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+                    "dev": true
+                }
+            }
+        },
+        "find-cache-dir": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
+            "integrity": "sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==",
+            "dev": true,
+            "requires": {
+                "commondir": "1.0.1",
+                "make-dir": "2.1.0",
+                "pkg-dir": "3.0.0"
+            }
+        },
+        "find-up": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+            "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+            "dev": true,
+            "requires": {
+                "locate-path": "3.0.0"
+            }
+        },
+        "findup-sync": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-3.0.0.tgz",
+            "integrity": "sha512-YbffarhcicEhOrm4CtrwdKBdCuz576RLdhJDsIfvNtxUuhdRet1qZcsMjqbePtAseKdAnDyM/IyXbu7PRPRLYg==",
+            "dev": true,
+            "requires": {
+                "detect-file": "1.0.0",
+                "is-glob": "4.0.1",
+                "micromatch": "3.1.10",
+                "resolve-dir": "1.0.1"
+            }
+        },
+        "flat-cache": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
+            "integrity": "sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==",
+            "dev": true,
+            "requires": {
+                "flatted": "2.0.1",
+                "rimraf": "2.6.3",
+                "write": "1.0.3"
+            }
+        },
+        "flatted": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.1.tgz",
+            "integrity": "sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg==",
+            "dev": true
+        },
+        "flatten": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/flatten/-/flatten-1.0.2.tgz",
+            "integrity": "sha1-2uRqnXj74lKSJYzB54CkHZXAN4I=",
+            "dev": true
+        },
+        "flush-write-stream": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.1.1.tgz",
+            "integrity": "sha512-3Z4XhFZ3992uIq0XOqb9AreonueSYphE6oYbpt5+3u06JWklbsPkNv3ZKkP9Bz/r+1MWCaMoSQ28P85+1Yc77w==",
+            "dev": true,
+            "requires": {
+                "inherits": "2.0.4",
+                "readable-stream": "2.3.6"
+            },
+            "dependencies": {
+                "isarray": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                    "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+                    "dev": true
+                },
+                "readable-stream": {
+                    "version": "2.3.6",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+                    "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+                    "dev": true,
+                    "requires": {
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.4",
+                        "isarray": "1.0.0",
+                        "process-nextick-args": "2.0.1",
+                        "safe-buffer": "5.1.2",
+                        "string_decoder": "1.1.1",
+                        "util-deprecate": "1.0.2"
+                    }
+                },
+                "string_decoder": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+                    "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+                    "dev": true,
+                    "requires": {
+                        "safe-buffer": "5.1.2"
+                    }
+                }
+            }
+        },
+        "follow-redirects": {
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.7.0.tgz",
+            "integrity": "sha512-m/pZQy4Gj287eNy94nivy5wchN3Kp+Q5WgUPNy5lJSZ3sgkVKSYV/ZChMAQVIgx1SqfZ2zBZtPA2YlXIWxxJOQ==",
+            "dev": true,
+            "requires": {
+                "debug": "3.2.6"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "3.2.6",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+                    "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.1.2"
+                    }
+                }
+            }
+        },
+        "for-in": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+            "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+            "dev": true
+        },
+        "forwarded": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
+            "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=",
+            "dev": true
+        },
+        "fragment-cache": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
+            "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
+            "dev": true,
+            "requires": {
+                "map-cache": "0.2.2"
+            }
+        },
+        "fresh": {
+            "version": "0.5.2",
+            "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+            "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
+            "dev": true
+        },
+        "from2": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
+            "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
+            "dev": true,
+            "requires": {
+                "inherits": "2.0.4",
+                "readable-stream": "2.3.6"
+            },
+            "dependencies": {
+                "isarray": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                    "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+                    "dev": true
+                },
+                "readable-stream": {
+                    "version": "2.3.6",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+                    "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+                    "dev": true,
+                    "requires": {
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.4",
+                        "isarray": "1.0.0",
+                        "process-nextick-args": "2.0.1",
+                        "safe-buffer": "5.1.2",
+                        "string_decoder": "1.1.1",
+                        "util-deprecate": "1.0.2"
+                    }
+                },
+                "string_decoder": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+                    "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+                    "dev": true,
+                    "requires": {
+                        "safe-buffer": "5.1.2"
+                    }
+                }
+            }
+        },
+        "fs-write-stream-atomic": {
+            "version": "1.0.10",
+            "resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
+            "integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "4.2.0",
+                "iferr": "0.1.5",
+                "imurmurhash": "0.1.4",
+                "readable-stream": "2.3.6"
+            },
+            "dependencies": {
+                "isarray": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                    "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+                    "dev": true
+                },
+                "readable-stream": {
+                    "version": "2.3.6",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+                    "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+                    "dev": true,
+                    "requires": {
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.4",
+                        "isarray": "1.0.0",
+                        "process-nextick-args": "2.0.1",
+                        "safe-buffer": "5.1.2",
+                        "string_decoder": "1.1.1",
+                        "util-deprecate": "1.0.2"
+                    }
+                },
+                "string_decoder": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+                    "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+                    "dev": true,
+                    "requires": {
+                        "safe-buffer": "5.1.2"
+                    }
+                }
+            }
+        },
+        "fs.realpath": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+            "dev": true
+        },
+        "fsevents": {
+            "version": "1.2.9",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.9.tgz",
+            "integrity": "sha512-oeyj2H3EjjonWcFjD5NvZNE9Rqe4UW+nQBU2HNeKw0koVLEFIhtyETyAakeAM3de7Z/SW5kcA+fZUait9EApnw==",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "nan": "2.14.0",
+                "node-pre-gyp": "0.12.0"
+            },
+            "dependencies": {
+                "abbrev": {
+                    "version": "1.1.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "ansi-regex": {
+                    "version": "2.1.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "aproba": {
+                    "version": "1.2.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "are-we-there-yet": {
+                    "version": "1.1.5",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "delegates": "1.0.0",
+                        "readable-stream": "2.3.6"
+                    }
+                },
+                "balanced-match": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "brace-expansion": {
+                    "version": "1.1.11",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "balanced-match": "1.0.0",
+                        "concat-map": "0.0.1"
+                    }
+                },
+                "chownr": {
+                    "version": "1.1.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "code-point-at": {
+                    "version": "1.1.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "concat-map": {
+                    "version": "0.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "console-control-strings": {
+                    "version": "1.1.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "core-util-is": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "debug": {
+                    "version": "4.1.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "ms": "2.1.1"
+                    }
+                },
+                "deep-extend": {
+                    "version": "0.6.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "delegates": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "detect-libc": {
+                    "version": "1.0.3",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "fs-minipass": {
+                    "version": "1.2.5",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "minipass": "2.3.5"
+                    }
+                },
+                "fs.realpath": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "gauge": {
+                    "version": "2.7.4",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "aproba": "1.2.0",
+                        "console-control-strings": "1.1.0",
+                        "has-unicode": "2.0.1",
+                        "object-assign": "4.1.1",
+                        "signal-exit": "3.0.2",
+                        "string-width": "1.0.2",
+                        "strip-ansi": "3.0.1",
+                        "wide-align": "1.1.3"
+                    }
+                },
+                "glob": {
+                    "version": "7.1.3",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "fs.realpath": "1.0.0",
+                        "inflight": "1.0.6",
+                        "inherits": "2.0.3",
+                        "minimatch": "3.0.4",
+                        "once": "1.4.0",
+                        "path-is-absolute": "1.0.1"
+                    }
+                },
+                "has-unicode": {
+                    "version": "2.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "iconv-lite": {
+                    "version": "0.4.24",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "safer-buffer": "2.1.2"
+                    }
+                },
+                "ignore-walk": {
+                    "version": "3.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "minimatch": "3.0.4"
+                    }
+                },
+                "inflight": {
+                    "version": "1.0.6",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "once": "1.4.0",
+                        "wrappy": "1.0.2"
+                    }
+                },
+                "inherits": {
+                    "version": "2.0.3",
+                    "bundled": true,
+                    "dev": true
+                },
+                "ini": {
+                    "version": "1.3.5",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "is-fullwidth-code-point": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "number-is-nan": "1.0.1"
+                    }
+                },
+                "isarray": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "minimatch": {
+                    "version": "3.0.4",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "brace-expansion": "1.1.11"
+                    }
+                },
+                "minimist": {
+                    "version": "0.0.8",
+                    "bundled": true,
+                    "dev": true
+                },
+                "minipass": {
+                    "version": "2.3.5",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "safe-buffer": "5.1.2",
+                        "yallist": "3.0.3"
+                    }
+                },
+                "minizlib": {
+                    "version": "1.2.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "minipass": "2.3.5"
+                    }
+                },
+                "mkdirp": {
+                    "version": "0.5.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "minimist": "0.0.8"
+                    }
+                },
+                "ms": {
+                    "version": "2.1.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "needle": {
+                    "version": "2.3.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "debug": "4.1.1",
+                        "iconv-lite": "0.4.24",
+                        "sax": "1.2.4"
+                    }
+                },
+                "node-pre-gyp": {
+                    "version": "0.12.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "detect-libc": "1.0.3",
+                        "mkdirp": "0.5.1",
+                        "needle": "2.3.0",
+                        "nopt": "4.0.1",
+                        "npm-packlist": "1.4.1",
+                        "npmlog": "4.1.2",
+                        "rc": "1.2.8",
+                        "rimraf": "2.6.3",
+                        "semver": "5.7.0",
+                        "tar": "4.4.8"
+                    }
+                },
+                "nopt": {
+                    "version": "4.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "abbrev": "1.1.1",
+                        "osenv": "0.1.5"
+                    }
+                },
+                "npm-bundled": {
+                    "version": "1.0.6",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "npm-packlist": {
+                    "version": "1.4.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "ignore-walk": "3.0.1",
+                        "npm-bundled": "1.0.6"
+                    }
+                },
+                "npmlog": {
+                    "version": "4.1.2",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "are-we-there-yet": "1.1.5",
+                        "console-control-strings": "1.1.0",
+                        "gauge": "2.7.4",
+                        "set-blocking": "2.0.0"
+                    }
+                },
+                "number-is-nan": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "object-assign": {
+                    "version": "4.1.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "once": {
+                    "version": "1.4.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "wrappy": "1.0.2"
+                    }
+                },
+                "os-homedir": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "os-tmpdir": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "osenv": {
+                    "version": "0.1.5",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "os-homedir": "1.0.2",
+                        "os-tmpdir": "1.0.2"
+                    }
+                },
+                "path-is-absolute": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "process-nextick-args": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "rc": {
+                    "version": "1.2.8",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "deep-extend": "0.6.0",
+                        "ini": "1.3.5",
+                        "minimist": "1.2.0",
+                        "strip-json-comments": "2.0.1"
+                    },
+                    "dependencies": {
+                        "minimist": {
+                            "version": "1.2.0",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true
+                        }
+                    }
+                },
+                "readable-stream": {
+                    "version": "2.3.6",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
+                        "isarray": "1.0.0",
+                        "process-nextick-args": "2.0.0",
+                        "safe-buffer": "5.1.2",
+                        "string_decoder": "1.1.1",
+                        "util-deprecate": "1.0.2"
+                    }
+                },
+                "rimraf": {
+                    "version": "2.6.3",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "glob": "7.1.3"
+                    }
+                },
+                "safe-buffer": {
+                    "version": "5.1.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "safer-buffer": {
+                    "version": "2.1.2",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "sax": {
+                    "version": "1.2.4",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "semver": {
+                    "version": "5.7.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "set-blocking": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "signal-exit": {
+                    "version": "3.0.2",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "string-width": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "code-point-at": "1.1.0",
+                        "is-fullwidth-code-point": "1.0.0",
+                        "strip-ansi": "3.0.1"
+                    }
+                },
+                "string_decoder": {
+                    "version": "1.1.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "safe-buffer": "5.1.2"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "3.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "2.1.1"
+                    }
+                },
+                "strip-json-comments": {
+                    "version": "2.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "tar": {
+                    "version": "4.4.8",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "chownr": "1.1.1",
+                        "fs-minipass": "1.2.5",
+                        "minipass": "2.3.5",
+                        "minizlib": "1.2.1",
+                        "mkdirp": "0.5.1",
+                        "safe-buffer": "5.1.2",
+                        "yallist": "3.0.3"
+                    }
+                },
+                "util-deprecate": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "wide-align": {
+                    "version": "1.1.3",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "string-width": "1.0.2"
+                    }
+                },
+                "wrappy": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "yallist": {
+                    "version": "3.0.3",
+                    "bundled": true,
+                    "dev": true
+                }
+            }
+        },
+        "function-bind": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+            "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+            "dev": true
+        },
+        "functional-red-black-tree": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+            "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+            "dev": true
+        },
+        "get-caller-file": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+            "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+            "dev": true
+        },
+        "get-stdin": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-7.0.0.tgz",
+            "integrity": "sha512-zRKcywvrXlXsA0v0i9Io4KDRaAw7+a1ZpjRwl9Wox8PFlVCCHra7E9c4kqXCoCM9nR5tBkaTTZRBoCm60bFqTQ==",
+            "dev": true
+        },
+        "get-stream": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+            "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+            "dev": true,
+            "requires": {
+                "pump": "3.0.0"
+            }
+        },
+        "get-value": {
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+            "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
+            "dev": true
+        },
+        "glob": {
+            "version": "7.1.4",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+            "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+            "dev": true,
+            "requires": {
+                "fs.realpath": "1.0.0",
+                "inflight": "1.0.6",
+                "inherits": "2.0.4",
+                "minimatch": "3.0.4",
+                "once": "1.4.0",
+                "path-is-absolute": "1.0.1"
+            }
+        },
+        "glob-parent": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+            "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+            "dev": true,
+            "requires": {
+                "is-glob": "3.1.0",
+                "path-dirname": "1.0.2"
+            },
+            "dependencies": {
+                "is-glob": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+                    "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+                    "dev": true,
+                    "requires": {
+                        "is-extglob": "2.1.1"
+                    }
+                }
+            }
+        },
+        "glob-to-regexp": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz",
+            "integrity": "sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs=",
+            "dev": true
+        },
+        "global": {
+            "version": "4.4.0",
+            "resolved": "https://registry.npmjs.org/global/-/global-4.4.0.tgz",
+            "integrity": "sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w==",
+            "requires": {
+                "min-document": "2.19.0",
+                "process": "0.11.10"
+            }
+        },
+        "global-modules": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-2.0.0.tgz",
+            "integrity": "sha512-NGbfmJBp9x8IxyJSd1P+otYK8vonoJactOogrVfFRIAEY1ukil8RSKDz2Yo7wh1oihl51l/r6W4epkeKJHqL8A==",
+            "dev": true,
+            "requires": {
+                "global-prefix": "3.0.0"
+            }
+        },
+        "global-prefix": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-3.0.0.tgz",
+            "integrity": "sha512-awConJSVCHVGND6x3tmMaKcQvwXLhjdkmomy2W+Goaui8YPgYgXJZewhg3fWC+DlfqqQuWg8AwqjGTD2nAPVWg==",
+            "dev": true,
+            "requires": {
+                "ini": "1.3.5",
+                "kind-of": "6.0.2",
+                "which": "1.3.1"
+            }
+        },
+        "globals": {
+            "version": "11.12.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+            "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+            "dev": true
+        },
+        "globby": {
+            "version": "9.2.0",
+            "resolved": "https://registry.npmjs.org/globby/-/globby-9.2.0.tgz",
+            "integrity": "sha512-ollPHROa5mcxDEkwg6bPt3QbEf4pDQSNtd6JPL1YvOvAo/7/0VAm9TccUeoTmarjPw4pfUthSCqcyfNB1I3ZSg==",
+            "dev": true,
+            "requires": {
+                "@types/glob": "7.1.1",
+                "array-union": "1.0.2",
+                "dir-glob": "2.2.2",
+                "fast-glob": "2.2.7",
+                "glob": "7.1.4",
+                "ignore": "4.0.6",
+                "pify": "4.0.1",
+                "slash": "2.0.0"
+            },
+            "dependencies": {
+                "slash": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+                    "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+                    "dev": true
+                }
+            }
+        },
+        "globjoin": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/globjoin/-/globjoin-0.1.4.tgz",
+            "integrity": "sha1-L0SUrIkZ43Z8XLtpHp9GMyQoXUM=",
+            "dev": true
+        },
+        "gonzales-pe": {
+            "version": "4.2.4",
+            "resolved": "https://registry.npmjs.org/gonzales-pe/-/gonzales-pe-4.2.4.tgz",
+            "integrity": "sha512-v0Ts/8IsSbh9n1OJRnSfa7Nlxi4AkXIsWB6vPept8FDbL4bXn3FNuxjYtO/nmBGu7GDkL9MFeGebeSu6l55EPQ==",
+            "dev": true,
+            "requires": {
+                "minimist": "1.1.3"
+            },
+            "dependencies": {
+                "minimist": {
+                    "version": "1.1.3",
+                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.3.tgz",
+                    "integrity": "sha1-O+39kaktOQFvz6ocaB6Pqhoe/ag=",
+                    "dev": true
+                }
+            }
+        },
+        "graceful-fs": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.0.tgz",
+            "integrity": "sha512-jpSvDPV4Cq/bgtpndIWbI5hmYxhQGHPC4d4cqBPb4DLniCfhJokdXhwhaDuLBGLQdvvRum/UiX6ECVIPvDXqdg==",
+            "dev": true
+        },
+        "gud": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/gud/-/gud-1.0.0.tgz",
+            "integrity": "sha512-zGEOVKFM5sVPPrYs7J5/hYEw2Pof8KCyOwyhG8sAF26mCAeUFAcYPu1mwB7hhpIP29zOIBaDqwuHdLp0jvZXjw=="
+        },
+        "handle-thing": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.0.tgz",
+            "integrity": "sha512-d4sze1JNC454Wdo2fkuyzCr6aHcbL6PGGuFAz0Li/NcOm1tCHGnWDRmJP85dh9IhQErTc2svWFEX5xHIOo//kQ==",
+            "dev": true
+        },
+        "has": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+            "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+            "dev": true,
+            "requires": {
+                "function-bind": "1.1.1"
+            }
+        },
+        "has-ansi": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+            "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+            "dev": true,
+            "requires": {
+                "ansi-regex": "2.1.1"
+            }
+        },
+        "has-flag": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+            "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+            "dev": true
+        },
+        "has-symbols": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
+            "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
+            "dev": true
+        },
+        "has-value": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
+            "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
+            "dev": true,
+            "requires": {
+                "get-value": "2.0.6",
+                "has-values": "1.0.0",
+                "isobject": "3.0.1"
+            }
+        },
+        "has-values": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
+            "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
+            "dev": true,
+            "requires": {
+                "is-number": "3.0.0",
+                "kind-of": "4.0.0"
+            },
+            "dependencies": {
+                "kind-of": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+                    "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+                    "dev": true,
+                    "requires": {
+                        "is-buffer": "1.1.6"
+                    }
+                }
+            }
+        },
+        "hash-base": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
+            "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
+            "dev": true,
+            "requires": {
+                "inherits": "2.0.4",
+                "safe-buffer": "5.1.2"
+            }
+        },
+        "hash.js": {
+            "version": "1.1.7",
+            "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
+            "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+            "dev": true,
+            "requires": {
+                "inherits": "2.0.4",
+                "minimalistic-assert": "1.0.1"
+            }
+        },
+        "he": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+            "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+            "dev": true
+        },
+        "hex-color-regex": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/hex-color-regex/-/hex-color-regex-1.1.0.tgz",
+            "integrity": "sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ==",
+            "dev": true
+        },
+        "history": {
+            "version": "4.9.0",
+            "resolved": "https://registry.npmjs.org/history/-/history-4.9.0.tgz",
+            "integrity": "sha512-H2DkjCjXf0Op9OAr6nJ56fcRkTSNrUiv41vNJ6IswJjif6wlpZK0BTfFbi7qK9dXLSYZxkq5lBsj3vUjlYBYZA==",
+            "requires": {
+                "@babel/runtime": "7.5.5",
+                "loose-envify": "1.4.0",
+                "resolve-pathname": "2.2.0",
+                "tiny-invariant": "1.0.6",
+                "tiny-warning": "1.0.3",
+                "value-equal": "0.4.0"
+            }
+        },
+        "hmac-drbg": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+            "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
+            "dev": true,
+            "requires": {
+                "hash.js": "1.1.7",
+                "minimalistic-assert": "1.0.1",
+                "minimalistic-crypto-utils": "1.0.1"
+            }
+        },
+        "hoist-non-react-statics": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.0.tgz",
+            "integrity": "sha512-0XsbTXxgiaCDYDIWFcwkmerZPSwywfUqYmwT4jzewKTQSWoE6FCMoUVOeBJWK3E/CrWbxRG3m5GzY4lnIwGRBA==",
+            "requires": {
+                "react-is": "16.8.6"
+            }
+        },
+        "homedir-polyfill": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
+            "integrity": "sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==",
+            "dev": true,
+            "requires": {
+                "parse-passwd": "1.0.0"
+            }
+        },
+        "hosted-git-info": {
+            "version": "2.7.1",
+            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
+            "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
+            "dev": true
+        },
+        "hpack.js": {
+            "version": "2.1.6",
+            "resolved": "https://registry.npmjs.org/hpack.js/-/hpack.js-2.1.6.tgz",
+            "integrity": "sha1-h3dMCUnlE/QuhFdbPEVoH63ioLI=",
+            "dev": true,
+            "requires": {
+                "inherits": "2.0.4",
+                "obuf": "1.1.2",
+                "readable-stream": "2.3.6",
+                "wbuf": "1.7.3"
+            },
+            "dependencies": {
+                "isarray": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                    "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+                    "dev": true
+                },
+                "readable-stream": {
+                    "version": "2.3.6",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+                    "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+                    "dev": true,
+                    "requires": {
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.4",
+                        "isarray": "1.0.0",
+                        "process-nextick-args": "2.0.1",
+                        "safe-buffer": "5.1.2",
+                        "string_decoder": "1.1.1",
+                        "util-deprecate": "1.0.2"
+                    }
+                },
+                "string_decoder": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+                    "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+                    "dev": true,
+                    "requires": {
+                        "safe-buffer": "5.1.2"
+                    }
+                }
+            }
+        },
+        "hsl-regex": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/hsl-regex/-/hsl-regex-1.0.0.tgz",
+            "integrity": "sha1-1JMwx4ntgZ4nakwNJy3/owsY/m4=",
+            "dev": true
+        },
+        "hsla-regex": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/hsla-regex/-/hsla-regex-1.0.0.tgz",
+            "integrity": "sha1-wc56MWjIxmFAM6S194d/OyJfnDg=",
+            "dev": true
+        },
+        "html-comment-regex": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/html-comment-regex/-/html-comment-regex-1.1.2.tgz",
+            "integrity": "sha512-P+M65QY2JQ5Y0G9KKdlDpo0zK+/OHptU5AaBwUfAIDJZk1MYf32Frm84EcOytfJE0t5JvkAnKlmjsXDnWzCJmQ==",
+            "dev": true
+        },
+        "html-entities": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-1.2.1.tgz",
+            "integrity": "sha1-DfKTUfByEWNRXfueVUPl9u7VFi8=",
+            "dev": true
+        },
+        "html-loader": {
+            "version": "0.5.5",
+            "resolved": "https://registry.npmjs.org/html-loader/-/html-loader-0.5.5.tgz",
+            "integrity": "sha512-7hIW7YinOYUpo//kSYcPB6dCKoceKLmOwjEMmhIobHuWGDVl0Nwe4l68mdG/Ru0wcUxQjVMEoZpkalZ/SE7zog==",
+            "dev": true,
+            "requires": {
+                "es6-templates": "0.2.3",
+                "fastparse": "1.1.2",
+                "html-minifier": "3.5.21",
+                "loader-utils": "1.2.3",
+                "object-assign": "4.1.1"
+            }
+        },
+        "html-minifier": {
+            "version": "3.5.21",
+            "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-3.5.21.tgz",
+            "integrity": "sha512-LKUKwuJDhxNa3uf/LPR/KVjm/l3rBqtYeCOAekvG8F1vItxMUpueGd94i/asDDr8/1u7InxzFA5EeGjhhG5mMA==",
+            "dev": true,
+            "requires": {
+                "camel-case": "3.0.0",
+                "clean-css": "4.2.1",
+                "commander": "2.17.1",
+                "he": "1.2.0",
+                "param-case": "2.1.1",
+                "relateurl": "0.2.7",
+                "uglify-js": "3.4.10"
+            },
+            "dependencies": {
+                "commander": {
+                    "version": "2.17.1",
+                    "resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
+                    "integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==",
+                    "dev": true
+                }
+            }
+        },
+        "html-tags": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/html-tags/-/html-tags-3.0.0.tgz",
+            "integrity": "sha512-xiXEBjihaNI+VZ2mKEoI5ZPxqUsevTKM+aeeJ/W4KAg2deGE35minmCJMn51BvwJZmiHaeAxrb2LAS0yZJxuuA==",
+            "dev": true
+        },
+        "html-webpack-plugin": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-3.2.0.tgz",
+            "integrity": "sha1-sBq71yOsqqeze2r0SS69oD2d03s=",
+            "dev": true,
+            "requires": {
+                "html-minifier": "3.5.21",
+                "loader-utils": "0.2.17",
+                "lodash": "4.17.15",
+                "pretty-error": "2.1.1",
+                "tapable": "1.1.3",
+                "toposort": "1.0.7",
+                "util.promisify": "1.0.0"
+            },
+            "dependencies": {
+                "big.js": {
+                    "version": "3.2.0",
+                    "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz",
+                    "integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q==",
+                    "dev": true
+                },
+                "json5": {
+                    "version": "0.5.1",
+                    "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+                    "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
+                    "dev": true
+                },
+                "loader-utils": {
+                    "version": "0.2.17",
+                    "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
+                    "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
+                    "dev": true,
+                    "requires": {
+                        "big.js": "3.2.0",
+                        "emojis-list": "2.1.0",
+                        "json5": "0.5.1",
+                        "object-assign": "4.1.1"
+                    }
+                }
+            }
+        },
+        "htmlparser2": {
+            "version": "3.10.1",
+            "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.1.tgz",
+            "integrity": "sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==",
+            "dev": true,
+            "requires": {
+                "domelementtype": "1.3.1",
+                "domhandler": "2.4.2",
+                "domutils": "1.7.0",
+                "entities": "1.1.2",
+                "inherits": "2.0.4",
+                "readable-stream": "3.4.0"
+            }
+        },
+        "http-deceiver": {
+            "version": "1.2.7",
+            "resolved": "https://registry.npmjs.org/http-deceiver/-/http-deceiver-1.2.7.tgz",
+            "integrity": "sha1-+nFolEq5pRnTN8sL7HKE3D5yPYc=",
+            "dev": true
+        },
+        "http-errors": {
+            "version": "1.7.2",
+            "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
+            "integrity": "sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==",
+            "dev": true,
+            "requires": {
+                "depd": "1.1.2",
+                "inherits": "2.0.3",
+                "setprototypeof": "1.1.1",
+                "statuses": "1.5.0",
+                "toidentifier": "1.0.0"
+            },
+            "dependencies": {
+                "inherits": {
+                    "version": "2.0.3",
+                    "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                    "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+                    "dev": true
+                }
+            }
+        },
+        "http-parser-js": {
+            "version": "0.4.10",
+            "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.4.10.tgz",
+            "integrity": "sha1-ksnBN0w1CF912zWexWzCV8u5P6Q=",
+            "dev": true
+        },
+        "http-proxy": {
+            "version": "1.17.0",
+            "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.17.0.tgz",
+            "integrity": "sha512-Taqn+3nNvYRfJ3bGvKfBSRwy1v6eePlm3oc/aWVxZp57DQr5Eq3xhKJi7Z4hZpS8PC3H4qI+Yly5EmFacGuA/g==",
+            "dev": true,
+            "requires": {
+                "eventemitter3": "3.1.2",
+                "follow-redirects": "1.7.0",
+                "requires-port": "1.0.0"
+            }
+        },
+        "http-proxy-middleware": {
+            "version": "0.19.1",
+            "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.19.1.tgz",
+            "integrity": "sha512-yHYTgWMQO8VvwNS22eLLloAkvungsKdKTLO8AJlftYIKNfJr3GK3zK0ZCfzDDGUBttdGc8xFy1mCitvNKQtC3Q==",
+            "dev": true,
+            "requires": {
+                "http-proxy": "1.17.0",
+                "is-glob": "4.0.1",
+                "lodash": "4.17.15",
+                "micromatch": "3.1.10"
+            }
+        },
+        "https-browserify": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
+            "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
+            "dev": true
+        },
+        "iconv-lite": {
+            "version": "0.4.24",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+            "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+            "dev": true,
+            "requires": {
+                "safer-buffer": "2.1.2"
+            }
+        },
+        "icss-utils": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-4.1.1.tgz",
+            "integrity": "sha512-4aFq7wvWyMHKgxsH8QQtGpvbASCf+eM3wPRLI6R+MgAnTCZ6STYsRvttLvRWK0Nfif5piF394St3HeJDaljGPA==",
+            "dev": true,
+            "requires": {
+                "postcss": "7.0.17"
+            }
+        },
+        "ieee754": {
+            "version": "1.1.13",
+            "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+            "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==",
+            "dev": true
+        },
+        "iferr": {
+            "version": "0.1.5",
+            "resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
+            "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
+            "dev": true
+        },
+        "ignore": {
+            "version": "4.0.6",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+            "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+            "dev": true
+        },
+        "import-cwd": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/import-cwd/-/import-cwd-2.1.0.tgz",
+            "integrity": "sha1-qmzzbnInYShcs3HsZRn1PiQ1sKk=",
+            "dev": true,
+            "requires": {
+                "import-from": "2.1.0"
+            }
+        },
+        "import-fresh": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-2.0.0.tgz",
+            "integrity": "sha1-2BNVwVYS04bGH53dOSLUMEgipUY=",
+            "dev": true,
+            "requires": {
+                "caller-path": "2.0.0",
+                "resolve-from": "3.0.0"
+            }
+        },
+        "import-from": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/import-from/-/import-from-2.1.0.tgz",
+            "integrity": "sha1-M1238qev/VOqpHHUuAId7ja387E=",
+            "dev": true,
+            "requires": {
+                "resolve-from": "3.0.0"
+            }
+        },
+        "import-lazy": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-4.0.0.tgz",
+            "integrity": "sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw==",
+            "dev": true
+        },
+        "import-local": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/import-local/-/import-local-2.0.0.tgz",
+            "integrity": "sha512-b6s04m3O+s3CGSbqDIyP4R6aAwAeYlVq9+WUWep6iHa8ETRf9yei1U48C5MmfJmV9AiLYYBKPMq/W+/WRpQmCQ==",
+            "dev": true,
+            "requires": {
+                "pkg-dir": "3.0.0",
+                "resolve-cwd": "2.0.0"
+            }
+        },
+        "imurmurhash": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+            "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+            "dev": true
+        },
+        "indent-string": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
+            "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
+            "dev": true
+        },
+        "indexes-of": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz",
+            "integrity": "sha1-8w9xbI4r00bHtn0985FVZqfAVgc=",
+            "dev": true
+        },
+        "inflight": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+            "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+            "dev": true,
+            "requires": {
+                "once": "1.4.0",
+                "wrappy": "1.0.2"
+            }
+        },
+        "inherits": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+            "dev": true
+        },
+        "ini": {
+            "version": "1.3.5",
+            "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+            "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+            "dev": true
+        },
+        "inquirer": {
+            "version": "6.5.0",
+            "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.5.0.tgz",
+            "integrity": "sha512-scfHejeG/lVZSpvCXpsB4j/wQNPM5JC8kiElOI0OUTwmc1RTpXr4H32/HOlQHcZiYl2z2VElwuCVDRG8vFmbnA==",
+            "dev": true,
+            "requires": {
+                "ansi-escapes": "3.2.0",
+                "chalk": "2.4.2",
+                "cli-cursor": "2.1.0",
+                "cli-width": "2.2.0",
+                "external-editor": "3.1.0",
+                "figures": "2.0.0",
+                "lodash": "4.17.15",
+                "mute-stream": "0.0.7",
+                "run-async": "2.3.0",
+                "rxjs": "6.5.2",
+                "string-width": "2.1.1",
+                "strip-ansi": "5.2.0",
+                "through": "2.3.8"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+                    "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+                    "dev": true
+                },
+                "strip-ansi": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+                    "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "4.1.0"
+                    }
+                }
+            }
+        },
+        "internal-ip": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/internal-ip/-/internal-ip-4.3.0.tgz",
+            "integrity": "sha512-S1zBo1D6zcsyuC6PMmY5+55YMILQ9av8lotMx447Bq6SAgo/sDK6y6uUKmuYhW7eacnIhFfsPmCNYdDzsnnDCg==",
+            "dev": true,
+            "requires": {
+                "default-gateway": "4.2.0",
+                "ipaddr.js": "1.9.0"
+            }
+        },
+        "interpret": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.2.0.tgz",
+            "integrity": "sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw==",
+            "dev": true
+        },
+        "invariant": {
+            "version": "2.2.4",
+            "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+            "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+            "dev": true,
+            "requires": {
+                "loose-envify": "1.4.0"
+            }
+        },
+        "invert-kv": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
+            "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==",
+            "dev": true
+        },
+        "ip": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
+            "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=",
+            "dev": true
+        },
+        "ip-regex": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz",
+            "integrity": "sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk=",
+            "dev": true
+        },
+        "ipaddr.js": {
+            "version": "1.9.0",
+            "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.0.tgz",
+            "integrity": "sha512-M4Sjn6N/+O6/IXSJseKqHoFc+5FdGJ22sXqnjTpdZweHK64MzEPAyQZyEU3R/KRv2GLoa7nNtg/C2Ev6m7z+eA==",
+            "dev": true
+        },
+        "is-absolute-url": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-2.1.0.tgz",
+            "integrity": "sha1-UFMN+4T8yap9vnhS6Do3uTufKqY=",
+            "dev": true
+        },
+        "is-accessor-descriptor": {
+            "version": "0.1.6",
+            "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+            "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+            "dev": true,
+            "requires": {
+                "kind-of": "3.2.2"
+            },
+            "dependencies": {
+                "kind-of": {
+                    "version": "3.2.2",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                    "dev": true,
+                    "requires": {
+                        "is-buffer": "1.1.6"
+                    }
+                }
+            }
+        },
+        "is-alphabetical": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-1.0.3.tgz",
+            "integrity": "sha512-eEMa6MKpHFzw38eKm56iNNi6GJ7lf6aLLio7Kr23sJPAECscgRtZvOBYybejWDQ2bM949Y++61PY+udzj5QMLA==",
+            "dev": true
+        },
+        "is-alphanumeric": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-alphanumeric/-/is-alphanumeric-1.0.0.tgz",
+            "integrity": "sha1-Spzvcdr0wAHB2B1j0UDPU/1oifQ=",
+            "dev": true
+        },
+        "is-alphanumerical": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.3.tgz",
+            "integrity": "sha512-A1IGAPO5AW9vSh7omxIlOGwIqEvpW/TA+DksVOPM5ODuxKlZS09+TEM1E3275lJqO2oJ38vDpeAL3DCIiHE6eA==",
+            "dev": true,
+            "requires": {
+                "is-alphabetical": "1.0.3",
+                "is-decimal": "1.0.3"
+            }
+        },
+        "is-arrayish": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+            "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+            "dev": true
+        },
+        "is-binary-path": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
+            "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
+            "dev": true,
+            "requires": {
+                "binary-extensions": "1.13.1"
+            }
+        },
+        "is-buffer": {
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+            "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+            "dev": true
+        },
+        "is-callable": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
+            "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
+            "dev": true
+        },
+        "is-color-stop": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/is-color-stop/-/is-color-stop-1.1.0.tgz",
+            "integrity": "sha1-z/9HGu5N1cnhWFmPvhKWe1za00U=",
+            "dev": true,
+            "requires": {
+                "css-color-names": "0.0.4",
+                "hex-color-regex": "1.1.0",
+                "hsl-regex": "1.0.0",
+                "hsla-regex": "1.0.0",
+                "rgb-regex": "1.0.1",
+                "rgba-regex": "1.0.0"
+            }
+        },
+        "is-data-descriptor": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+            "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+            "dev": true,
+            "requires": {
+                "kind-of": "3.2.2"
+            },
+            "dependencies": {
+                "kind-of": {
+                    "version": "3.2.2",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                    "dev": true,
+                    "requires": {
+                        "is-buffer": "1.1.6"
+                    }
+                }
+            }
+        },
+        "is-date-object": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
+            "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+            "dev": true
+        },
+        "is-decimal": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-1.0.3.tgz",
+            "integrity": "sha512-bvLSwoDg2q6Gf+E2LEPiklHZxxiSi3XAh4Mav65mKqTfCO1HM3uBs24TjEH8iJX3bbDdLXKJXBTmGzuTUuAEjQ==",
+            "dev": true
+        },
+        "is-descriptor": {
+            "version": "0.1.6",
+            "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+            "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+            "dev": true,
+            "requires": {
+                "is-accessor-descriptor": "0.1.6",
+                "is-data-descriptor": "0.1.4",
+                "kind-of": "5.1.0"
+            },
+            "dependencies": {
+                "kind-of": {
+                    "version": "5.1.0",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+                    "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+                    "dev": true
+                }
+            }
+        },
+        "is-directory": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz",
+            "integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=",
+            "dev": true
+        },
+        "is-extendable": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+            "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+            "dev": true
+        },
+        "is-extglob": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+            "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+            "dev": true
+        },
+        "is-fullwidth-code-point": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+            "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+            "dev": true
+        },
+        "is-glob": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+            "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+            "dev": true,
+            "requires": {
+                "is-extglob": "2.1.1"
+            }
+        },
+        "is-hexadecimal": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.3.tgz",
+            "integrity": "sha512-zxQ9//Q3D/34poZf8fiy3m3XVpbQc7ren15iKqrTtLPwkPD/t3Scy9Imp63FujULGxuK0ZlCwoo5xNpktFgbOA==",
+            "dev": true
+        },
+        "is-number": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+            "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+            "dev": true,
+            "requires": {
+                "kind-of": "3.2.2"
+            },
+            "dependencies": {
+                "kind-of": {
+                    "version": "3.2.2",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                    "dev": true,
+                    "requires": {
+                        "is-buffer": "1.1.6"
+                    }
+                }
+            }
+        },
+        "is-obj": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+            "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
+            "dev": true
+        },
+        "is-path-cwd": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-2.2.0.tgz",
+            "integrity": "sha512-w942bTcih8fdJPJmQHFzkS76NEP8Kzzvmw92cXsazb8intwLqPibPPdXf4ANdKV3rYMuuQYGIWtvz9JilB3NFQ==",
+            "dev": true
+        },
+        "is-path-in-cwd": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-2.1.0.tgz",
+            "integrity": "sha512-rNocXHgipO+rvnP6dk3zI20RpOtrAM/kzbB258Uw5BWr3TpXi861yzjo16Dn4hUox07iw5AyeMLHWsujkjzvRQ==",
+            "dev": true,
+            "requires": {
+                "is-path-inside": "2.1.0"
+            }
+        },
+        "is-path-inside": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-2.1.0.tgz",
+            "integrity": "sha512-wiyhTzfDWsvwAW53OBWF5zuvaOGlZ6PwYxAbPVDhpm+gM09xKQGjBq/8uYN12aDvMxnAnq3dxTyoSoRNmg5YFg==",
+            "dev": true,
+            "requires": {
+                "path-is-inside": "1.0.2"
+            }
+        },
+        "is-plain-obj": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+            "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
+            "dev": true
+        },
+        "is-plain-object": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+            "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+            "dev": true,
+            "requires": {
+                "isobject": "3.0.1"
+            }
+        },
+        "is-promise": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
+            "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
+            "dev": true
+        },
+        "is-regex": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
+            "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+            "dev": true,
+            "requires": {
+                "has": "1.0.3"
+            }
+        },
+        "is-regexp": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-2.1.0.tgz",
+            "integrity": "sha512-OZ4IlER3zmRIoB9AqNhEggVxqIH4ofDns5nRrPS6yQxXE1TPCUpFznBfRQmQa8uC+pXqjMnukiJBxCisIxiLGA==",
+            "dev": true
+        },
+        "is-resolvable": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
+            "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
+            "dev": true
+        },
+        "is-stream": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+            "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+            "dev": true
+        },
+        "is-svg": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/is-svg/-/is-svg-3.0.0.tgz",
+            "integrity": "sha512-gi4iHK53LR2ujhLVVj+37Ykh9GLqYHX6JOVXbLAucaG/Cqw9xwdFOjDM2qeifLs1sF1npXXFvDu0r5HNgCMrzQ==",
+            "dev": true,
+            "requires": {
+                "html-comment-regex": "1.1.2"
+            }
+        },
+        "is-symbol": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
+            "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
+            "dev": true,
+            "requires": {
+                "has-symbols": "1.0.0"
+            }
+        },
+        "is-whitespace-character": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/is-whitespace-character/-/is-whitespace-character-1.0.3.tgz",
+            "integrity": "sha512-SNPgMLz9JzPccD3nPctcj8sZlX9DAMJSKH8bP7Z6bohCwuNgX8xbWr1eTAYXX9Vpi/aSn8Y1akL9WgM3t43YNQ==",
+            "dev": true
+        },
+        "is-windows": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+            "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+            "dev": true
+        },
+        "is-word-character": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/is-word-character/-/is-word-character-1.0.3.tgz",
+            "integrity": "sha512-0wfcrFgOOOBdgRNT9H33xe6Zi6yhX/uoc4U8NBZGeQQB0ctU1dnlNTyL9JM2646bHDTpsDm1Brb3VPoCIMrd/A==",
+            "dev": true
+        },
+        "is-wsl": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
+            "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=",
+            "dev": true
+        },
+        "isarray": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+            "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "isexe": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+            "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+            "dev": true
+        },
+        "isobject": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+            "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+            "dev": true
+        },
+        "js-base64": {
+            "version": "2.5.1",
+            "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.5.1.tgz",
+            "integrity": "sha512-M7kLczedRMYX4L8Mdh4MzyAMM9O5osx+4FcOQuTvr3A9F2D9S5JXheN0ewNbrvK2UatkTRhL5ejGmGSjNMiZuw==",
+            "dev": true
+        },
+        "js-levenshtein": {
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.6.tgz",
+            "integrity": "sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==",
+            "dev": true
+        },
+        "js-tokens": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+            "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+        },
+        "js-yaml": {
+            "version": "3.13.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+            "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+            "dev": true,
+            "requires": {
+                "argparse": "1.0.10",
+                "esprima": "4.0.1"
+            }
+        },
+        "jsesc": {
+            "version": "2.5.2",
+            "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+            "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+            "dev": true
+        },
+        "json-parse-better-errors": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+            "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+            "dev": true
+        },
+        "json-schema-traverse": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+            "dev": true
+        },
+        "json-stable-stringify-without-jsonify": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+            "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+            "dev": true
+        },
+        "json3": {
+            "version": "3.3.3",
+            "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.3.tgz",
+            "integrity": "sha512-c7/8mbUsKigAbLkD5B010BK4D9LZm7A1pNItkEwiUZRpIN66exu/e7YQWysGun+TRKaJp8MhemM+VkfWv42aCA==",
+            "dev": true
+        },
+        "json5": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+            "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+            "requires": {
+                "minimist": "1.2.0"
+            }
+        },
+        "jsx-ast-utils": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.2.1.tgz",
+            "integrity": "sha512-v3FxCcAf20DayI+uxnCuw795+oOIkVu6EnJ1+kSzhqqTZHNkTZ7B66ZgLp4oLJ/gbA64cI0B7WRoHZMSRdyVRQ==",
+            "dev": true,
+            "requires": {
+                "array-includes": "3.0.3",
+                "object.assign": "4.1.0"
+            }
+        },
+        "killable": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/killable/-/killable-1.0.1.tgz",
+            "integrity": "sha512-LzqtLKlUwirEUyl/nicirVmNiPvYs7l5n8wOPP7fyJVpUPkvCnW/vuiXGpylGUlnPDnB7311rARzAt3Mhswpjg==",
+            "dev": true
+        },
+        "kind-of": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+            "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+            "dev": true
+        },
+        "known-css-properties": {
+            "version": "0.14.0",
+            "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.14.0.tgz",
+            "integrity": "sha512-P+0a/gBzLgVlCnK8I7VcD0yuYJscmWn66wH9tlKsQnmVdg689tLEmziwB9PuazZYLkcm07fvWOKCJJqI55sD5Q==",
+            "dev": true
+        },
+        "lcid": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
+            "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
+            "dev": true,
+            "requires": {
+                "invert-kv": "2.0.0"
+            }
+        },
+        "leven": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
+            "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
+            "dev": true
+        },
+        "levn": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+            "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+            "dev": true,
+            "requires": {
+                "prelude-ls": "1.1.2",
+                "type-check": "0.3.2"
+            }
+        },
+        "load-json-file": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+            "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "4.2.0",
+                "parse-json": "2.2.0",
+                "pify": "2.3.0",
+                "strip-bom": "3.0.0"
+            },
+            "dependencies": {
+                "parse-json": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+                    "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+                    "dev": true,
+                    "requires": {
+                        "error-ex": "1.3.2"
+                    }
+                },
+                "pify": {
+                    "version": "2.3.0",
+                    "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+                    "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+                    "dev": true
+                }
+            }
+        },
+        "loader-fs-cache": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/loader-fs-cache/-/loader-fs-cache-1.0.2.tgz",
+            "integrity": "sha512-70IzT/0/L+M20jUlEqZhZyArTU6VKLRTYRDAYN26g4jfzpJqjipLL3/hgYpySqI9PwsVRHHFja0LfEmsx9X2Cw==",
+            "dev": true,
+            "requires": {
+                "find-cache-dir": "0.1.1",
+                "mkdirp": "0.5.1"
+            },
+            "dependencies": {
+                "find-cache-dir": {
+                    "version": "0.1.1",
+                    "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-0.1.1.tgz",
+                    "integrity": "sha1-yN765XyKUqinhPnjHFfHQumToLk=",
+                    "dev": true,
+                    "requires": {
+                        "commondir": "1.0.1",
+                        "mkdirp": "0.5.1",
+                        "pkg-dir": "1.0.0"
+                    }
+                },
+                "find-up": {
+                    "version": "1.1.2",
+                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+                    "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+                    "dev": true,
+                    "requires": {
+                        "path-exists": "2.1.0",
+                        "pinkie-promise": "2.0.1"
+                    }
+                },
+                "path-exists": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+                    "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+                    "dev": true,
+                    "requires": {
+                        "pinkie-promise": "2.0.1"
+                    }
+                },
+                "pkg-dir": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
+                    "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
+                    "dev": true,
+                    "requires": {
+                        "find-up": "1.1.2"
+                    }
+                }
+            }
+        },
+        "loader-runner": {
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-2.4.0.tgz",
+            "integrity": "sha512-Jsmr89RcXGIwivFY21FcRrisYZfvLMTWx5kOLc+JTxtpBOG6xML0vzbc6SEQG2FO9/4Fc3wW4LVcB5DmGflaRw==",
+            "dev": true
+        },
+        "loader-utils": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.2.3.tgz",
+            "integrity": "sha512-fkpz8ejdnEMG3s37wGL07iSBDg99O9D5yflE9RGNH3hRdx9SOwYfnGYdZOUIZitN8E+E2vkq3MUMYMvPYl5ZZA==",
+            "requires": {
+                "big.js": "5.2.2",
+                "emojis-list": "2.1.0",
+                "json5": "1.0.1"
+            }
+        },
+        "locate-path": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+            "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+            "dev": true,
+            "requires": {
+                "p-locate": "3.0.0",
+                "path-exists": "3.0.0"
+            }
+        },
+        "lodash": {
+            "version": "4.17.15",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+            "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+            "dev": true
+        },
+        "lodash._reinterpolate": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
+            "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
+            "dev": true
+        },
+        "lodash.memoize": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
+            "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
+            "dev": true
+        },
+        "lodash.template": {
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.5.0.tgz",
+            "integrity": "sha512-84vYFxIkmidUiFxidA/KjjH9pAycqW+h980j7Fuz5qxRtO9pgB7MDFTdys1N7A5mcucRiDyEq4fusljItR1T/A==",
+            "dev": true,
+            "requires": {
+                "lodash._reinterpolate": "3.0.0",
+                "lodash.templatesettings": "4.2.0"
+            }
+        },
+        "lodash.templatesettings": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.2.0.tgz",
+            "integrity": "sha512-stgLz+i3Aa9mZgnjr/O+v9ruKZsPsndy7qPZOchbqk2cnTU1ZaldKK+v7m54WoKIyxiuMZTKT2H81F8BeAc3ZQ==",
+            "dev": true,
+            "requires": {
+                "lodash._reinterpolate": "3.0.0"
+            }
+        },
+        "lodash.uniq": {
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+            "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
+            "dev": true
+        },
+        "log-symbols": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
+            "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
+            "dev": true,
+            "requires": {
+                "chalk": "2.4.2"
+            }
+        },
+        "loglevel": {
+            "version": "1.6.3",
+            "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.3.tgz",
+            "integrity": "sha512-LoEDv5pgpvWgPF4kNYuIp0qqSJVWak/dML0RY74xlzMZiT9w77teNAwKYKWBTYjlokMirg+o3jBwp+vlLrcfAA==",
+            "dev": true
+        },
+        "longest-streak": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-2.0.3.tgz",
+            "integrity": "sha512-9lz5IVdpwsKLMzQi0MQ+oD9EA0mIGcWYP7jXMTZVXP8D42PwuAk+M/HBFYQoxt1G5OR8m7aSIgb1UymfWGBWEw==",
+            "dev": true
+        },
+        "loose-envify": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+            "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+            "requires": {
+                "js-tokens": "4.0.0"
+            }
+        },
+        "loud-rejection": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
+            "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
+            "dev": true,
+            "requires": {
+                "currently-unhandled": "0.4.1",
+                "signal-exit": "3.0.2"
+            }
+        },
+        "lower-case": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.4.tgz",
+            "integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw=",
+            "dev": true
+        },
+        "lru-cache": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+            "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+            "dev": true,
+            "requires": {
+                "yallist": "3.0.3"
+            }
+        },
+        "make-dir": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
+            "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
+            "dev": true,
+            "requires": {
+                "pify": "4.0.1",
+                "semver": "5.7.0"
+            }
+        },
+        "mamacro": {
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/mamacro/-/mamacro-0.0.3.tgz",
+            "integrity": "sha512-qMEwh+UujcQ+kbz3T6V+wAmO2U8veoq2w+3wY8MquqwVA3jChfwY+Tk52GZKDfACEPjuZ7r2oJLejwpt8jtwTA==",
+            "dev": true
+        },
+        "map-age-cleaner": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
+            "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
+            "dev": true,
+            "requires": {
+                "p-defer": "1.0.0"
+            }
+        },
+        "map-cache": {
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
+            "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
+            "dev": true
+        },
+        "map-obj": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-2.0.0.tgz",
+            "integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk=",
+            "dev": true
+        },
+        "map-visit": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
+            "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
+            "dev": true,
+            "requires": {
+                "object-visit": "1.0.1"
+            }
+        },
+        "markdown-escapes": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/markdown-escapes/-/markdown-escapes-1.0.3.tgz",
+            "integrity": "sha512-XUi5HJhhV5R74k8/0H2oCbCiYf/u4cO/rX8tnGkRvrqhsr5BRNU6Mg0yt/8UIx1iIS8220BNJsDb7XnILhLepw==",
+            "dev": true
+        },
+        "markdown-table": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-1.1.3.tgz",
+            "integrity": "sha512-1RUZVgQlpJSPWYbFSpmudq5nHY1doEIv89gBtF0s4gW1GF2XorxcA/70M5vq7rLv0a6mhOUccRsqkwhwLCIQ2Q==",
+            "dev": true
+        },
+        "mathml-tag-names": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/mathml-tag-names/-/mathml-tag-names-2.1.1.tgz",
+            "integrity": "sha512-pWB896KPGSGkp1XtyzRBftpTzwSOL0Gfk0wLvxt4f2mgzjY19o0LxJ3U25vNWTzsh7da+KTbuXQoQ3lOJZ8WHw==",
+            "dev": true
+        },
+        "md5.js": {
+            "version": "1.3.5",
+            "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
+            "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
+            "dev": true,
+            "requires": {
+                "hash-base": "3.0.4",
+                "inherits": "2.0.4",
+                "safe-buffer": "5.1.2"
+            }
+        },
+        "mdast-util-compact": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/mdast-util-compact/-/mdast-util-compact-1.0.3.tgz",
+            "integrity": "sha512-nRiU5GpNy62rZppDKbLwhhtw5DXoFMqw9UNZFmlPsNaQCZ//WLjGKUwWMdJrUH+Se7UvtO2gXtAMe0g/N+eI5w==",
+            "dev": true,
+            "requires": {
+                "unist-util-visit": "1.4.1"
+            }
+        },
+        "mdn-data": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.4.tgz",
+            "integrity": "sha512-iV3XNKw06j5Q7mi6h+9vbx23Tv7JkjEVgKHW4pimwyDGWm0OIQntJJ+u1C6mg6mK1EaTv42XQ7w76yuzH7M2cA==",
+            "dev": true
+        },
+        "media-typer": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+            "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
+            "dev": true
+        },
+        "mem": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/mem/-/mem-4.3.0.tgz",
+            "integrity": "sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==",
+            "dev": true,
+            "requires": {
+                "map-age-cleaner": "0.1.3",
+                "mimic-fn": "2.1.0",
+                "p-is-promise": "2.1.0"
+            },
+            "dependencies": {
+                "mimic-fn": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+                    "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+                    "dev": true
+                }
+            }
+        },
+        "memory-fs": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
+            "integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
+            "dev": true,
+            "requires": {
+                "errno": "0.1.7",
+                "readable-stream": "2.3.6"
+            },
+            "dependencies": {
+                "isarray": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                    "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+                    "dev": true
+                },
+                "readable-stream": {
+                    "version": "2.3.6",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+                    "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+                    "dev": true,
+                    "requires": {
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.4",
+                        "isarray": "1.0.0",
+                        "process-nextick-args": "2.0.1",
+                        "safe-buffer": "5.1.2",
+                        "string_decoder": "1.1.1",
+                        "util-deprecate": "1.0.2"
+                    }
+                },
+                "string_decoder": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+                    "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+                    "dev": true,
+                    "requires": {
+                        "safe-buffer": "5.1.2"
+                    }
+                }
+            }
+        },
+        "meow": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/meow/-/meow-5.0.0.tgz",
+            "integrity": "sha512-CbTqYU17ABaLefO8vCU153ZZlprKYWDljcndKKDCFcYQITzWCXZAVk4QMFZPgvzrnUQ3uItnIE/LoUOwrT15Ig==",
+            "dev": true,
+            "requires": {
+                "camelcase-keys": "4.2.0",
+                "decamelize-keys": "1.1.0",
+                "loud-rejection": "1.6.0",
+                "minimist-options": "3.0.2",
+                "normalize-package-data": "2.5.0",
+                "read-pkg-up": "3.0.0",
+                "redent": "2.0.0",
+                "trim-newlines": "2.0.0",
+                "yargs-parser": "10.1.0"
+            },
+            "dependencies": {
+                "find-up": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+                    "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+                    "dev": true,
+                    "requires": {
+                        "locate-path": "2.0.0"
+                    }
+                },
+                "load-json-file": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+                    "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+                    "dev": true,
+                    "requires": {
+                        "graceful-fs": "4.2.0",
+                        "parse-json": "4.0.0",
+                        "pify": "3.0.0",
+                        "strip-bom": "3.0.0"
+                    }
+                },
+                "locate-path": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+                    "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+                    "dev": true,
+                    "requires": {
+                        "p-locate": "2.0.0",
+                        "path-exists": "3.0.0"
+                    }
+                },
+                "p-limit": {
+                    "version": "1.3.0",
+                    "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+                    "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+                    "dev": true,
+                    "requires": {
+                        "p-try": "1.0.0"
+                    }
+                },
+                "p-locate": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+                    "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+                    "dev": true,
+                    "requires": {
+                        "p-limit": "1.3.0"
+                    }
+                },
+                "p-try": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+                    "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+                    "dev": true
+                },
+                "path-type": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+                    "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+                    "dev": true,
+                    "requires": {
+                        "pify": "3.0.0"
+                    }
+                },
+                "pify": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+                    "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+                    "dev": true
+                },
+                "read-pkg": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+                    "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+                    "dev": true,
+                    "requires": {
+                        "load-json-file": "4.0.0",
+                        "normalize-package-data": "2.5.0",
+                        "path-type": "3.0.0"
+                    }
+                },
+                "read-pkg-up": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
+                    "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
+                    "dev": true,
+                    "requires": {
+                        "find-up": "2.1.0",
+                        "read-pkg": "3.0.0"
+                    }
+                }
+            }
+        },
+        "merge-descriptors": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+            "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
+            "dev": true
+        },
+        "merge2": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.2.3.tgz",
+            "integrity": "sha512-gdUU1Fwj5ep4kplwcmftruWofEFt6lfpkkr3h860CXbAB9c3hGb55EOL2ali0Td5oebvW0E1+3Sr+Ur7XfKpRA==",
+            "dev": true
+        },
+        "methods": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+            "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
+            "dev": true
+        },
+        "micromatch": {
+            "version": "3.1.10",
+            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+            "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+            "dev": true,
+            "requires": {
+                "arr-diff": "4.0.0",
+                "array-unique": "0.3.2",
+                "braces": "2.3.2",
+                "define-property": "2.0.2",
+                "extend-shallow": "3.0.2",
+                "extglob": "2.0.4",
+                "fragment-cache": "0.2.1",
+                "kind-of": "6.0.2",
+                "nanomatch": "1.2.13",
+                "object.pick": "1.3.0",
+                "regex-not": "1.0.2",
+                "snapdragon": "0.8.2",
+                "to-regex": "3.0.2"
+            }
+        },
+        "miller-rabin": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
+            "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
+            "dev": true,
+            "requires": {
+                "bn.js": "4.11.8",
+                "brorand": "1.1.0"
+            }
+        },
+        "mime": {
+            "version": "2.4.4",
+            "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.4.tgz",
+            "integrity": "sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA==",
+            "dev": true
+        },
+        "mime-db": {
+            "version": "1.40.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
+            "integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA==",
+            "dev": true
+        },
+        "mime-types": {
+            "version": "2.1.24",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.24.tgz",
+            "integrity": "sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==",
+            "dev": true,
+            "requires": {
+                "mime-db": "1.40.0"
+            }
+        },
+        "mimic-fn": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+            "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+            "dev": true
+        },
+        "min-document": {
+            "version": "2.19.0",
+            "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
+            "integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
+            "requires": {
+                "dom-walk": "0.1.1"
+            }
+        },
+        "mini-create-react-context": {
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/mini-create-react-context/-/mini-create-react-context-0.3.2.tgz",
+            "integrity": "sha512-2v+OeetEyliMt5VHMXsBhABoJ0/M4RCe7fatd/fBy6SMiKazUSEt3gxxypfnk2SHMkdBYvorHRoQxuGoiwbzAw==",
+            "requires": {
+                "@babel/runtime": "7.5.5",
+                "gud": "1.0.0",
+                "tiny-warning": "1.0.3"
+            }
+        },
+        "mini-css-extract-plugin": {
+            "version": "0.8.0",
+            "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-0.8.0.tgz",
+            "integrity": "sha512-MNpRGbNA52q6U92i0qbVpQNsgk7LExy41MdAlG84FeytfDOtRIf/mCHdEgG8rpTKOaNKiqUnZdlptF469hxqOw==",
+            "dev": true,
+            "requires": {
+                "loader-utils": "1.2.3",
+                "normalize-url": "1.9.1",
+                "schema-utils": "1.0.0",
+                "webpack-sources": "1.3.0"
+            },
+            "dependencies": {
+                "normalize-url": {
+                    "version": "1.9.1",
+                    "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-1.9.1.tgz",
+                    "integrity": "sha1-LMDWazHqIwNkWENuNiDYWVTGbDw=",
+                    "dev": true,
+                    "requires": {
+                        "object-assign": "4.1.1",
+                        "prepend-http": "1.0.4",
+                        "query-string": "4.3.4",
+                        "sort-keys": "1.1.2"
+                    }
+                }
+            }
+        },
+        "minimalistic-assert": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+            "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+            "dev": true
+        },
+        "minimalistic-crypto-utils": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+            "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=",
+            "dev": true
+        },
+        "minimatch": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+            "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+            "dev": true,
+            "requires": {
+                "brace-expansion": "1.1.11"
+            }
+        },
+        "minimist": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+            "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+        },
+        "minimist-options": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-3.0.2.tgz",
+            "integrity": "sha512-FyBrT/d0d4+uiZRbqznPXqw3IpZZG3gl3wKWiX784FycUKVwBt0uLBFkQrtE4tZOrgo78nZp2jnKz3L65T5LdQ==",
+            "dev": true,
+            "requires": {
+                "arrify": "1.0.1",
+                "is-plain-obj": "1.1.0"
+            }
+        },
+        "mississippi": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/mississippi/-/mississippi-3.0.0.tgz",
+            "integrity": "sha512-x471SsVjUtBRtcvd4BzKE9kFC+/2TeWgKCgw0bZcw1b9l2X3QX5vCWgF+KaZaYm87Ss//rHnWryupDrgLvmSkA==",
+            "dev": true,
+            "requires": {
+                "concat-stream": "1.6.2",
+                "duplexify": "3.7.1",
+                "end-of-stream": "1.4.1",
+                "flush-write-stream": "1.1.1",
+                "from2": "2.3.0",
+                "parallel-transform": "1.1.0",
+                "pump": "3.0.0",
+                "pumpify": "1.5.1",
+                "stream-each": "1.2.3",
+                "through2": "2.0.5"
+            }
+        },
+        "mixin-deep": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
+            "integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
+            "dev": true,
+            "requires": {
+                "for-in": "1.0.2",
+                "is-extendable": "1.0.1"
+            },
+            "dependencies": {
+                "is-extendable": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+                    "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+                    "dev": true,
+                    "requires": {
+                        "is-plain-object": "2.0.4"
+                    }
+                }
+            }
+        },
+        "mkdirp": {
+            "version": "0.5.1",
+            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+            "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+            "dev": true,
+            "requires": {
+                "minimist": "0.0.8"
+            },
+            "dependencies": {
+                "minimist": {
+                    "version": "0.0.8",
+                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                    "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+                    "dev": true
+                }
+            }
+        },
+        "move-concurrently": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
+            "integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
+            "dev": true,
+            "requires": {
+                "aproba": "1.2.0",
+                "copy-concurrently": "1.0.5",
+                "fs-write-stream-atomic": "1.0.10",
+                "mkdirp": "0.5.1",
+                "rimraf": "2.6.3",
+                "run-queue": "1.0.3"
+            }
+        },
+        "ms": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+            "dev": true
+        },
+        "multicast-dns": {
+            "version": "6.2.3",
+            "resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-6.2.3.tgz",
+            "integrity": "sha512-ji6J5enbMyGRHIAkAOu3WdV8nggqviKCEKtXcOqfphZZtQrmHKycfynJ2V7eVPUA4NhJ6V7Wf4TmGbTwKE9B6g==",
+            "dev": true,
+            "requires": {
+                "dns-packet": "1.3.1",
+                "thunky": "1.0.3"
+            }
+        },
+        "multicast-dns-service-types": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/multicast-dns-service-types/-/multicast-dns-service-types-1.1.0.tgz",
+            "integrity": "sha1-iZ8R2WhuXgXLkbNdXw5jt3PPyQE=",
+            "dev": true
+        },
+        "mute-stream": {
+            "version": "0.0.7",
+            "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+            "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+            "dev": true
+        },
+        "nan": {
+            "version": "2.14.0",
+            "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+            "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
+            "dev": true,
+            "optional": true
+        },
+        "nanomatch": {
+            "version": "1.2.13",
+            "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
+            "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
+            "dev": true,
+            "requires": {
+                "arr-diff": "4.0.0",
+                "array-unique": "0.3.2",
+                "define-property": "2.0.2",
+                "extend-shallow": "3.0.2",
+                "fragment-cache": "0.2.1",
+                "is-windows": "1.0.2",
+                "kind-of": "6.0.2",
+                "object.pick": "1.3.0",
+                "regex-not": "1.0.2",
+                "snapdragon": "0.8.2",
+                "to-regex": "3.0.2"
+            }
+        },
+        "natural-compare": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+            "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+            "dev": true
+        },
+        "negotiator": {
+            "version": "0.6.2",
+            "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
+            "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==",
+            "dev": true
+        },
+        "neo-async": {
+            "version": "2.6.1",
+            "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
+            "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==",
+            "dev": true
+        },
+        "nice-try": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+            "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
+            "dev": true
+        },
+        "no-case": {
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/no-case/-/no-case-2.3.2.tgz",
+            "integrity": "sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==",
+            "dev": true,
+            "requires": {
+                "lower-case": "1.1.4"
+            }
+        },
+        "node-forge": {
+            "version": "0.7.5",
+            "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.7.5.tgz",
+            "integrity": "sha512-MmbQJ2MTESTjt3Gi/3yG1wGpIMhUfcIypUCGtTizFR9IiccFwxSpfp0vtIZlkFclEqERemxfnSdZEMR9VqqEFQ==",
+            "dev": true
+        },
+        "node-libs-browser": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.2.1.tgz",
+            "integrity": "sha512-h/zcD8H9kaDZ9ALUWwlBUDo6TKF8a7qBSCSEGfjTVIYeqsioSKaAX+BN7NgiMGp6iSIXZ3PxgCu8KS3b71YK5Q==",
+            "dev": true,
+            "requires": {
+                "assert": "1.5.0",
+                "browserify-zlib": "0.2.0",
+                "buffer": "4.9.1",
+                "console-browserify": "1.1.0",
+                "constants-browserify": "1.0.0",
+                "crypto-browserify": "3.12.0",
+                "domain-browser": "1.2.0",
+                "events": "3.0.0",
+                "https-browserify": "1.0.0",
+                "os-browserify": "0.3.0",
+                "path-browserify": "0.0.1",
+                "process": "0.11.10",
+                "punycode": "1.4.1",
+                "querystring-es3": "0.2.1",
+                "readable-stream": "2.3.6",
+                "stream-browserify": "2.0.2",
+                "stream-http": "2.8.3",
+                "string_decoder": "1.2.0",
+                "timers-browserify": "2.0.10",
+                "tty-browserify": "0.0.0",
+                "url": "0.11.0",
+                "util": "0.11.1",
+                "vm-browserify": "1.1.0"
+            },
+            "dependencies": {
+                "isarray": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                    "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+                    "dev": true
+                },
+                "punycode": {
+                    "version": "1.4.1",
+                    "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+                    "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+                    "dev": true
+                },
+                "readable-stream": {
+                    "version": "2.3.6",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+                    "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+                    "dev": true,
+                    "requires": {
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.4",
+                        "isarray": "1.0.0",
+                        "process-nextick-args": "2.0.1",
+                        "safe-buffer": "5.1.2",
+                        "string_decoder": "1.1.1",
+                        "util-deprecate": "1.0.2"
+                    },
+                    "dependencies": {
+                        "string_decoder": {
+                            "version": "1.1.1",
+                            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+                            "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+                            "dev": true,
+                            "requires": {
+                                "safe-buffer": "5.1.2"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "node-releases": {
+            "version": "1.1.25",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.25.tgz",
+            "integrity": "sha512-fI5BXuk83lKEoZDdH3gRhtsNgh05/wZacuXkgbiYkceE7+QIMXOg98n9ZV7mz27B+kFHnqHcUpscZZlGRSmTpQ==",
+            "dev": true,
+            "requires": {
+                "semver": "5.7.0"
+            }
+        },
+        "normalize-package-data": {
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+            "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+            "dev": true,
+            "requires": {
+                "hosted-git-info": "2.7.1",
+                "resolve": "1.11.1",
+                "semver": "5.7.0",
+                "validate-npm-package-license": "3.0.4"
+            }
+        },
+        "normalize-path": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+            "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+            "dev": true
+        },
+        "normalize-range": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
+            "integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI=",
+            "dev": true
+        },
+        "normalize-selector": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/normalize-selector/-/normalize-selector-0.2.0.tgz",
+            "integrity": "sha1-0LFF62kRicY6eNIB3E/bEpPvDAM=",
+            "dev": true
+        },
+        "normalize-url": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-3.3.0.tgz",
+            "integrity": "sha512-U+JJi7duF1o+u2pynbp2zXDW2/PADgC30f0GsHZtRh+HOcXHnw137TrNlyxxRvWW5fjKd3bcLHPxofWuCjaeZg==",
+            "dev": true
+        },
+        "npm-run-path": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+            "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+            "dev": true,
+            "requires": {
+                "path-key": "2.0.1"
+            }
+        },
+        "nth-check": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.2.tgz",
+            "integrity": "sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==",
+            "dev": true,
+            "requires": {
+                "boolbase": "1.0.0"
+            }
+        },
+        "num2fraction": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz",
+            "integrity": "sha1-b2gragJ6Tp3fpFZM0lidHU5mnt4=",
+            "dev": true
+        },
+        "number-is-nan": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+            "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+            "dev": true
+        },
+        "object-assign": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+            "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+        },
+        "object-copy": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
+            "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
+            "dev": true,
+            "requires": {
+                "copy-descriptor": "0.1.1",
+                "define-property": "0.2.5",
+                "kind-of": "3.2.2"
+            },
+            "dependencies": {
+                "define-property": {
+                    "version": "0.2.5",
+                    "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+                    "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+                    "dev": true,
+                    "requires": {
+                        "is-descriptor": "0.1.6"
+                    }
+                },
+                "kind-of": {
+                    "version": "3.2.2",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                    "dev": true,
+                    "requires": {
+                        "is-buffer": "1.1.6"
+                    }
+                }
+            }
+        },
+        "object-hash": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-1.3.1.tgz",
+            "integrity": "sha512-OSuu/pU4ENM9kmREg0BdNrUDIl1heYa4mBZacJc+vVWz4GtAwu7jO8s4AIt2aGRUTqxykpWzI3Oqnsm13tTMDA==",
+            "dev": true
+        },
+        "object-keys": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+            "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+            "dev": true
+        },
+        "object-visit": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
+            "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
+            "dev": true,
+            "requires": {
+                "isobject": "3.0.1"
+            }
+        },
+        "object.assign": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
+            "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+            "dev": true,
+            "requires": {
+                "define-properties": "1.1.3",
+                "function-bind": "1.1.1",
+                "has-symbols": "1.0.0",
+                "object-keys": "1.1.1"
+            }
+        },
+        "object.entries": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.0.tgz",
+            "integrity": "sha512-l+H6EQ8qzGRxbkHOd5I/aHRhHDKoQXQ8g0BYt4uSweQU1/J6dZUOyWh9a2Vky35YCKjzmgxOzta2hH6kf9HuXA==",
+            "dev": true,
+            "requires": {
+                "define-properties": "1.1.3",
+                "es-abstract": "1.13.0",
+                "function-bind": "1.1.1",
+                "has": "1.0.3"
+            }
+        },
+        "object.fromentries": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.0.tgz",
+            "integrity": "sha512-9iLiI6H083uiqUuvzyY6qrlmc/Gz8hLQFOcb/Ri/0xXFkSNS3ctV+CbE6yM2+AnkYfOB3dGjdzC0wrMLIhQICA==",
+            "dev": true,
+            "requires": {
+                "define-properties": "1.1.3",
+                "es-abstract": "1.13.0",
+                "function-bind": "1.1.1",
+                "has": "1.0.3"
+            }
+        },
+        "object.getownpropertydescriptors": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
+            "integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
+            "dev": true,
+            "requires": {
+                "define-properties": "1.1.3",
+                "es-abstract": "1.13.0"
+            }
+        },
+        "object.pick": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
+            "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
+            "dev": true,
+            "requires": {
+                "isobject": "3.0.1"
+            }
+        },
+        "object.values": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.0.tgz",
+            "integrity": "sha512-8mf0nKLAoFX6VlNVdhGj31SVYpaNFtUnuoOXWyFEstsWRgU837AK+JYM0iAxwkSzGRbwn8cbFmgbyxj1j4VbXg==",
+            "dev": true,
+            "requires": {
+                "define-properties": "1.1.3",
+                "es-abstract": "1.13.0",
+                "function-bind": "1.1.1",
+                "has": "1.0.3"
+            }
+        },
+        "obuf": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
+            "integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==",
+            "dev": true
+        },
+        "offline-plugin": {
+            "version": "5.0.7",
+            "resolved": "https://registry.npmjs.org/offline-plugin/-/offline-plugin-5.0.7.tgz",
+            "integrity": "sha512-ArMFt4QFjK0wg8B5+R/6tt65u6Dk+Pkx4PAcW5O7mgIF3ywMepaQqFOQgfZD4ybanuGwuJihxUwMRgkzd+YGYw==",
+            "dev": true,
+            "requires": {
+                "deep-extend": "0.5.1",
+                "ejs": "2.6.2",
+                "loader-utils": "0.2.17",
+                "minimatch": "3.0.4",
+                "slash": "1.0.0"
+            },
+            "dependencies": {
+                "big.js": {
+                    "version": "3.2.0",
+                    "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz",
+                    "integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q==",
+                    "dev": true
+                },
+                "json5": {
+                    "version": "0.5.1",
+                    "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+                    "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
+                    "dev": true
+                },
+                "loader-utils": {
+                    "version": "0.2.17",
+                    "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
+                    "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
+                    "dev": true,
+                    "requires": {
+                        "big.js": "3.2.0",
+                        "emojis-list": "2.1.0",
+                        "json5": "0.5.1",
+                        "object-assign": "4.1.1"
+                    }
+                }
+            }
+        },
+        "on-finished": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+            "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+            "dev": true,
+            "requires": {
+                "ee-first": "1.1.1"
+            }
+        },
+        "on-headers": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
+            "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==",
+            "dev": true
+        },
+        "once": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+            "dev": true,
+            "requires": {
+                "wrappy": "1.0.2"
+            }
+        },
+        "onetime": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+            "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+            "dev": true,
+            "requires": {
+                "mimic-fn": "1.2.0"
+            }
+        },
+        "opn": {
+            "version": "5.5.0",
+            "resolved": "https://registry.npmjs.org/opn/-/opn-5.5.0.tgz",
+            "integrity": "sha512-PqHpggC9bLV0VeWcdKhkpxY+3JTzetLSqTCWL/z/tFIbI6G8JCjondXklT1JinczLz2Xib62sSp0T/gKT4KksA==",
+            "dev": true,
+            "requires": {
+                "is-wsl": "1.1.0"
+            }
+        },
+        "optionator": {
+            "version": "0.8.2",
+            "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+            "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+            "dev": true,
+            "requires": {
+                "deep-is": "0.1.3",
+                "fast-levenshtein": "2.0.6",
+                "levn": "0.3.0",
+                "prelude-ls": "1.1.2",
+                "type-check": "0.3.2",
+                "wordwrap": "1.0.0"
+            }
+        },
+        "original": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/original/-/original-1.0.2.tgz",
+            "integrity": "sha512-hyBVl6iqqUOJ8FqRe+l/gS8H+kKYjrEndd5Pm1MfBtsEKA038HkkdbAl/72EAXGyonD/PFsvmVG+EvcIpliMBg==",
+            "dev": true,
+            "requires": {
+                "url-parse": "1.4.7"
+            }
+        },
+        "os-browserify": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
+            "integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc=",
+            "dev": true
+        },
+        "os-locale": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
+            "integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
+            "dev": true,
+            "requires": {
+                "execa": "1.0.0",
+                "lcid": "2.0.0",
+                "mem": "4.3.0"
+            }
+        },
+        "os-tmpdir": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+            "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+            "dev": true
+        },
+        "p-defer": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
+            "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=",
+            "dev": true
+        },
+        "p-finally": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+            "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+            "dev": true
+        },
+        "p-is-promise": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.1.0.tgz",
+            "integrity": "sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg==",
+            "dev": true
+        },
+        "p-limit": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
+            "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
+            "dev": true,
+            "requires": {
+                "p-try": "2.2.0"
+            }
+        },
+        "p-locate": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+            "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+            "dev": true,
+            "requires": {
+                "p-limit": "2.2.0"
+            }
+        },
+        "p-map": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
+            "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==",
+            "dev": true
+        },
+        "p-retry": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-3.0.1.tgz",
+            "integrity": "sha512-XE6G4+YTTkT2a0UWb2kjZe8xNwf8bIbnqpc/IS/idOBVhyves0mK5OJgeocjx7q5pvX/6m23xuzVPYT1uGM73w==",
+            "dev": true,
+            "requires": {
+                "retry": "0.12.0"
+            }
+        },
+        "p-try": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+            "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+            "dev": true
+        },
+        "pako": {
+            "version": "1.0.10",
+            "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.10.tgz",
+            "integrity": "sha512-0DTvPVU3ed8+HNXOu5Bs+o//Mbdj9VNQMUOe9oKCwh8l0GNwpTDMKCWbRjgtD291AWnkAgkqA/LOnQS8AmS1tw==",
+            "dev": true
+        },
+        "parallel-transform": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-1.1.0.tgz",
+            "integrity": "sha1-1BDwZbBdojCB/NEPKIVMKb2jOwY=",
+            "dev": true,
+            "requires": {
+                "cyclist": "0.2.2",
+                "inherits": "2.0.4",
+                "readable-stream": "2.3.6"
+            },
+            "dependencies": {
+                "isarray": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                    "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+                    "dev": true
+                },
+                "readable-stream": {
+                    "version": "2.3.6",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+                    "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+                    "dev": true,
+                    "requires": {
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.4",
+                        "isarray": "1.0.0",
+                        "process-nextick-args": "2.0.1",
+                        "safe-buffer": "5.1.2",
+                        "string_decoder": "1.1.1",
+                        "util-deprecate": "1.0.2"
+                    }
+                },
+                "string_decoder": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+                    "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+                    "dev": true,
+                    "requires": {
+                        "safe-buffer": "5.1.2"
+                    }
+                }
+            }
+        },
+        "param-case": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/param-case/-/param-case-2.1.1.tgz",
+            "integrity": "sha1-35T9jPZTHs915r75oIWPvHK+Ikc=",
+            "dev": true,
+            "requires": {
+                "no-case": "2.3.2"
+            }
+        },
+        "parent-module": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+            "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+            "dev": true,
+            "requires": {
+                "callsites": "3.1.0"
+            },
+            "dependencies": {
+                "callsites": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+                    "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+                    "dev": true
+                }
+            }
+        },
+        "parse-asn1": {
+            "version": "5.1.4",
+            "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.4.tgz",
+            "integrity": "sha512-Qs5duJcuvNExRfFZ99HDD3z4mAi3r9Wl/FOjEOijlxwCZs7E7mW2vjTpgQ4J8LpTF8x5v+1Vn5UQFejmWT11aw==",
+            "dev": true,
+            "requires": {
+                "asn1.js": "4.10.1",
+                "browserify-aes": "1.2.0",
+                "create-hash": "1.2.0",
+                "evp_bytestokey": "1.0.3",
+                "pbkdf2": "3.0.17",
+                "safe-buffer": "5.1.2"
+            }
+        },
+        "parse-entities": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-1.2.2.tgz",
+            "integrity": "sha512-NzfpbxW/NPrzZ/yYSoQxyqUZMZXIdCfE0OIN4ESsnptHJECoUk3FZktxNuzQf4tjt5UEopnxpYJbvYuxIFDdsg==",
+            "dev": true,
+            "requires": {
+                "character-entities": "1.2.3",
+                "character-entities-legacy": "1.1.3",
+                "character-reference-invalid": "1.1.3",
+                "is-alphanumerical": "1.0.3",
+                "is-decimal": "1.0.3",
+                "is-hexadecimal": "1.0.3"
+            }
+        },
+        "parse-json": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+            "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+            "dev": true,
+            "requires": {
+                "error-ex": "1.3.2",
+                "json-parse-better-errors": "1.0.2"
+            }
+        },
+        "parse-passwd": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
+            "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=",
+            "dev": true
+        },
+        "parseurl": {
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+            "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+            "dev": true
+        },
+        "pascalcase": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
+            "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
+            "dev": true
+        },
+        "path-browserify": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.1.tgz",
+            "integrity": "sha512-BapA40NHICOS+USX9SN4tyhq+A2RrN/Ws5F0Z5aMHDp98Fl86lX8Oti8B7uN93L4Ifv4fHOEA+pQw87gmMO/lQ==",
+            "dev": true
+        },
+        "path-dirname": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
+            "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
+            "dev": true
+        },
+        "path-exists": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+            "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+            "dev": true
+        },
+        "path-is-absolute": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+            "dev": true
+        },
+        "path-is-inside": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+            "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+            "dev": true
+        },
+        "path-key": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+            "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+            "dev": true
+        },
+        "path-parse": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+            "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+            "dev": true
+        },
+        "path-to-regexp": {
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
+            "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+            "requires": {
+                "isarray": "0.0.1"
+            }
+        },
+        "path-type": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
+            "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+            "dev": true,
+            "requires": {
+                "pify": "2.3.0"
+            },
+            "dependencies": {
+                "pify": {
+                    "version": "2.3.0",
+                    "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+                    "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+                    "dev": true
+                }
+            }
+        },
+        "pbkdf2": {
+            "version": "3.0.17",
+            "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.17.tgz",
+            "integrity": "sha512-U/il5MsrZp7mGg3mSQfn742na2T+1/vHDCG5/iTI3X9MKUuYUZVLQhyRsg06mCgDBTd57TxzgZt7P+fYfjRLtA==",
+            "dev": true,
+            "requires": {
+                "create-hash": "1.2.0",
+                "create-hmac": "1.1.7",
+                "ripemd160": "2.0.2",
+                "safe-buffer": "5.1.2",
+                "sha.js": "2.4.11"
+            }
+        },
+        "picomatch": {
+            "version": "2.0.7",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.0.7.tgz",
+            "integrity": "sha512-oLHIdio3tZ0qH76NybpeneBhYVj0QFTfXEFTc/B3zKQspYfYYkWYgFsmzo+4kvId/bQRcNkVeguI3y+CD22BtA==",
+            "dev": true
+        },
+        "pify": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+            "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+            "dev": true
+        },
+        "pinkie": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+            "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+            "dev": true
+        },
+        "pinkie-promise": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+            "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+            "dev": true,
+            "requires": {
+                "pinkie": "2.0.4"
+            }
+        },
+        "pkg-dir": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
+            "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
+            "dev": true,
+            "requires": {
+                "find-up": "3.0.0"
+            }
+        },
+        "portfinder": {
+            "version": "1.0.21",
+            "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.21.tgz",
+            "integrity": "sha512-ESabpDCzmBS3ekHbmpAIiESq3udRsCBGiBZLsC+HgBKv2ezb0R4oG+7RnYEVZ/ZCfhel5Tx3UzdNWA0Lox2QCA==",
+            "dev": true,
+            "requires": {
+                "async": "1.5.2",
+                "debug": "2.6.9",
+                "mkdirp": "0.5.1"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "2.6.9",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+                    "dev": true
+                }
+            }
+        },
+        "posix-character-classes": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
+            "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
+            "dev": true
+        },
+        "postcss": {
+            "version": "7.0.17",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.17.tgz",
+            "integrity": "sha512-546ZowA+KZ3OasvQZHsbuEpysvwTZNGJv9EfyCQdsIDltPSWHAeTQ5fQy/Npi2ZDtLI3zs7Ps/p6wThErhm9fQ==",
+            "dev": true,
+            "requires": {
+                "chalk": "2.4.2",
+                "source-map": "0.6.1",
+                "supports-color": "6.1.0"
+            },
+            "dependencies": {
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "6.1.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+                    "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "3.0.0"
+                    }
+                }
+            }
+        },
+        "postcss-attribute-case-insensitive": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/postcss-attribute-case-insensitive/-/postcss-attribute-case-insensitive-4.0.1.tgz",
+            "integrity": "sha512-L2YKB3vF4PetdTIthQVeT+7YiSzMoNMLLYxPXXppOOP7NoazEAy45sh2LvJ8leCQjfBcfkYQs8TtCcQjeZTp8A==",
+            "dev": true,
+            "requires": {
+                "postcss": "7.0.17",
+                "postcss-selector-parser": "5.0.0"
+            },
+            "dependencies": {
+                "cssesc": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-2.0.0.tgz",
+                    "integrity": "sha512-MsCAG1z9lPdoO/IUMLSBWBSVxVtJ1395VGIQ+Fc2gNdkQ1hNDnQdw3YhA71WJCBW1vdwA0cAnk/DnW6bqoEUYg==",
+                    "dev": true
+                },
+                "postcss-selector-parser": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-5.0.0.tgz",
+                    "integrity": "sha512-w+zLE5Jhg6Liz8+rQOWEAwtwkyqpfnmsinXjXg6cY7YIONZZtgvE0v2O0uhQBs0peNomOJwWRKt6JBfTdTd3OQ==",
+                    "dev": true,
+                    "requires": {
+                        "cssesc": "2.0.0",
+                        "indexes-of": "1.0.1",
+                        "uniq": "1.0.1"
+                    }
+                }
+            }
+        },
+        "postcss-calc": {
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-7.0.1.tgz",
+            "integrity": "sha512-oXqx0m6tb4N3JGdmeMSc/i91KppbYsFZKdH0xMOqK8V1rJlzrKlTdokz8ozUXLVejydRN6u2IddxpcijRj2FqQ==",
+            "dev": true,
+            "requires": {
+                "css-unit-converter": "1.1.1",
+                "postcss": "7.0.17",
+                "postcss-selector-parser": "5.0.0",
+                "postcss-value-parser": "3.3.1"
+            },
+            "dependencies": {
+                "cssesc": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-2.0.0.tgz",
+                    "integrity": "sha512-MsCAG1z9lPdoO/IUMLSBWBSVxVtJ1395VGIQ+Fc2gNdkQ1hNDnQdw3YhA71WJCBW1vdwA0cAnk/DnW6bqoEUYg==",
+                    "dev": true
+                },
+                "postcss-selector-parser": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-5.0.0.tgz",
+                    "integrity": "sha512-w+zLE5Jhg6Liz8+rQOWEAwtwkyqpfnmsinXjXg6cY7YIONZZtgvE0v2O0uhQBs0peNomOJwWRKt6JBfTdTd3OQ==",
+                    "dev": true,
+                    "requires": {
+                        "cssesc": "2.0.0",
+                        "indexes-of": "1.0.1",
+                        "uniq": "1.0.1"
+                    }
+                }
+            }
+        },
+        "postcss-color-functional-notation": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/postcss-color-functional-notation/-/postcss-color-functional-notation-2.0.1.tgz",
+            "integrity": "sha512-ZBARCypjEDofW4P6IdPVTLhDNXPRn8T2s1zHbZidW6rPaaZvcnCS2soYFIQJrMZSxiePJ2XIYTlcb2ztr/eT2g==",
+            "dev": true,
+            "requires": {
+                "postcss": "7.0.17",
+                "postcss-values-parser": "2.0.1"
+            }
+        },
+        "postcss-color-gray": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-color-gray/-/postcss-color-gray-5.0.0.tgz",
+            "integrity": "sha512-q6BuRnAGKM/ZRpfDascZlIZPjvwsRye7UDNalqVz3s7GDxMtqPY6+Q871liNxsonUw8oC61OG+PSaysYpl1bnw==",
+            "dev": true,
+            "requires": {
+                "@csstools/convert-colors": "1.4.0",
+                "postcss": "7.0.17",
+                "postcss-values-parser": "2.0.1"
+            }
+        },
+        "postcss-color-hex-alpha": {
+            "version": "5.0.3",
+            "resolved": "https://registry.npmjs.org/postcss-color-hex-alpha/-/postcss-color-hex-alpha-5.0.3.tgz",
+            "integrity": "sha512-PF4GDel8q3kkreVXKLAGNpHKilXsZ6xuu+mOQMHWHLPNyjiUBOr75sp5ZKJfmv1MCus5/DWUGcK9hm6qHEnXYw==",
+            "dev": true,
+            "requires": {
+                "postcss": "7.0.17",
+                "postcss-values-parser": "2.0.1"
+            }
+        },
+        "postcss-color-mod-function": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/postcss-color-mod-function/-/postcss-color-mod-function-3.0.3.tgz",
+            "integrity": "sha512-YP4VG+xufxaVtzV6ZmhEtc+/aTXH3d0JLpnYfxqTvwZPbJhWqp8bSY3nfNzNRFLgB4XSaBA82OE4VjOOKpCdVQ==",
+            "dev": true,
+            "requires": {
+                "@csstools/convert-colors": "1.4.0",
+                "postcss": "7.0.17",
+                "postcss-values-parser": "2.0.1"
+            }
+        },
+        "postcss-color-rebeccapurple": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/postcss-color-rebeccapurple/-/postcss-color-rebeccapurple-4.0.1.tgz",
+            "integrity": "sha512-aAe3OhkS6qJXBbqzvZth2Au4V3KieR5sRQ4ptb2b2O8wgvB3SJBsdG+jsn2BZbbwekDG8nTfcCNKcSfe/lEy8g==",
+            "dev": true,
+            "requires": {
+                "postcss": "7.0.17",
+                "postcss-values-parser": "2.0.1"
+            }
+        },
+        "postcss-colormin": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-4.0.3.tgz",
+            "integrity": "sha512-WyQFAdDZpExQh32j0U0feWisZ0dmOtPl44qYmJKkq9xFWY3p+4qnRzCHeNrkeRhwPHz9bQ3mo0/yVkaply0MNw==",
+            "dev": true,
+            "requires": {
+                "browserslist": "4.6.6",
+                "color": "3.1.2",
+                "has": "1.0.3",
+                "postcss": "7.0.17",
+                "postcss-value-parser": "3.3.1"
+            }
+        },
+        "postcss-convert-values": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-4.0.1.tgz",
+            "integrity": "sha512-Kisdo1y77KUC0Jmn0OXU/COOJbzM8cImvw1ZFsBgBgMgb1iL23Zs/LXRe3r+EZqM3vGYKdQ2YJVQ5VkJI+zEJQ==",
+            "dev": true,
+            "requires": {
+                "postcss": "7.0.17",
+                "postcss-value-parser": "3.3.1"
+            }
+        },
+        "postcss-custom-media": {
+            "version": "7.0.8",
+            "resolved": "https://registry.npmjs.org/postcss-custom-media/-/postcss-custom-media-7.0.8.tgz",
+            "integrity": "sha512-c9s5iX0Ge15o00HKbuRuTqNndsJUbaXdiNsksnVH8H4gdc+zbLzr/UasOwNG6CTDpLFekVY4672eWdiiWu2GUg==",
+            "dev": true,
+            "requires": {
+                "postcss": "7.0.17"
+            }
+        },
+        "postcss-custom-properties": {
+            "version": "8.0.11",
+            "resolved": "https://registry.npmjs.org/postcss-custom-properties/-/postcss-custom-properties-8.0.11.tgz",
+            "integrity": "sha512-nm+o0eLdYqdnJ5abAJeXp4CEU1c1k+eB2yMCvhgzsds/e0umabFrN6HoTy/8Q4K5ilxERdl/JD1LO5ANoYBeMA==",
+            "dev": true,
+            "requires": {
+                "postcss": "7.0.17",
+                "postcss-values-parser": "2.0.1"
+            }
+        },
+        "postcss-custom-selectors": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/postcss-custom-selectors/-/postcss-custom-selectors-5.1.2.tgz",
+            "integrity": "sha512-DSGDhqinCqXqlS4R7KGxL1OSycd1lydugJ1ky4iRXPHdBRiozyMHrdu0H3o7qNOCiZwySZTUI5MV0T8QhCLu+w==",
+            "dev": true,
+            "requires": {
+                "postcss": "7.0.17",
+                "postcss-selector-parser": "5.0.0"
+            },
+            "dependencies": {
+                "cssesc": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-2.0.0.tgz",
+                    "integrity": "sha512-MsCAG1z9lPdoO/IUMLSBWBSVxVtJ1395VGIQ+Fc2gNdkQ1hNDnQdw3YhA71WJCBW1vdwA0cAnk/DnW6bqoEUYg==",
+                    "dev": true
+                },
+                "postcss-selector-parser": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-5.0.0.tgz",
+                    "integrity": "sha512-w+zLE5Jhg6Liz8+rQOWEAwtwkyqpfnmsinXjXg6cY7YIONZZtgvE0v2O0uhQBs0peNomOJwWRKt6JBfTdTd3OQ==",
+                    "dev": true,
+                    "requires": {
+                        "cssesc": "2.0.0",
+                        "indexes-of": "1.0.1",
+                        "uniq": "1.0.1"
+                    }
+                }
+            }
+        },
+        "postcss-dir-pseudo-class": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-dir-pseudo-class/-/postcss-dir-pseudo-class-5.0.0.tgz",
+            "integrity": "sha512-3pm4oq8HYWMZePJY+5ANriPs3P07q+LW6FAdTlkFH2XqDdP4HeeJYMOzn0HYLhRSjBO3fhiqSwwU9xEULSrPgw==",
+            "dev": true,
+            "requires": {
+                "postcss": "7.0.17",
+                "postcss-selector-parser": "5.0.0"
+            },
+            "dependencies": {
+                "cssesc": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-2.0.0.tgz",
+                    "integrity": "sha512-MsCAG1z9lPdoO/IUMLSBWBSVxVtJ1395VGIQ+Fc2gNdkQ1hNDnQdw3YhA71WJCBW1vdwA0cAnk/DnW6bqoEUYg==",
+                    "dev": true
+                },
+                "postcss-selector-parser": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-5.0.0.tgz",
+                    "integrity": "sha512-w+zLE5Jhg6Liz8+rQOWEAwtwkyqpfnmsinXjXg6cY7YIONZZtgvE0v2O0uhQBs0peNomOJwWRKt6JBfTdTd3OQ==",
+                    "dev": true,
+                    "requires": {
+                        "cssesc": "2.0.0",
+                        "indexes-of": "1.0.1",
+                        "uniq": "1.0.1"
+                    }
+                }
+            }
+        },
+        "postcss-discard-comments": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-4.0.2.tgz",
+            "integrity": "sha512-RJutN259iuRf3IW7GZyLM5Sw4GLTOH8FmsXBnv8Ab/Tc2k4SR4qbV4DNbyyY4+Sjo362SyDmW2DQ7lBSChrpkg==",
+            "dev": true,
+            "requires": {
+                "postcss": "7.0.17"
+            }
+        },
+        "postcss-discard-duplicates": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-4.0.2.tgz",
+            "integrity": "sha512-ZNQfR1gPNAiXZhgENFfEglF93pciw0WxMkJeVmw8eF+JZBbMD7jp6C67GqJAXVZP2BWbOztKfbsdmMp/k8c6oQ==",
+            "dev": true,
+            "requires": {
+                "postcss": "7.0.17"
+            }
+        },
+        "postcss-discard-empty": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-4.0.1.tgz",
+            "integrity": "sha512-B9miTzbznhDjTfjvipfHoqbWKwd0Mj+/fL5s1QOz06wufguil+Xheo4XpOnc4NqKYBCNqqEzgPv2aPBIJLox0w==",
+            "dev": true,
+            "requires": {
+                "postcss": "7.0.17"
+            }
+        },
+        "postcss-discard-overridden": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-4.0.1.tgz",
+            "integrity": "sha512-IYY2bEDD7g1XM1IDEsUT4//iEYCxAmP5oDSFMVU/JVvT7gh+l4fmjciLqGgwjdWpQIdb0Che2VX00QObS5+cTg==",
+            "dev": true,
+            "requires": {
+                "postcss": "7.0.17"
+            }
+        },
+        "postcss-double-position-gradients": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-double-position-gradients/-/postcss-double-position-gradients-1.0.0.tgz",
+            "integrity": "sha512-G+nV8EnQq25fOI8CH/B6krEohGWnF5+3A6H/+JEpOncu5dCnkS1QQ6+ct3Jkaepw1NGVqqOZH6lqrm244mCftA==",
+            "dev": true,
+            "requires": {
+                "postcss": "7.0.17",
+                "postcss-values-parser": "2.0.1"
+            }
+        },
+        "postcss-env-function": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/postcss-env-function/-/postcss-env-function-2.0.2.tgz",
+            "integrity": "sha512-rwac4BuZlITeUbiBq60h/xbLzXY43qOsIErngWa4l7Mt+RaSkT7QBjXVGTcBHupykkblHMDrBFh30zchYPaOUw==",
+            "dev": true,
+            "requires": {
+                "postcss": "7.0.17",
+                "postcss-values-parser": "2.0.1"
+            }
+        },
+        "postcss-extend": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/postcss-extend/-/postcss-extend-1.0.5.tgz",
+            "integrity": "sha1-XqmL94e6PKz030YJdD+AqDOx0Oc=",
+            "dev": true,
+            "requires": {
+                "postcss": "5.2.18"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "2.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+                    "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+                    "dev": true
+                },
+                "chalk": {
+                    "version": "1.1.3",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                    "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "2.2.1",
+                        "escape-string-regexp": "1.0.5",
+                        "has-ansi": "2.0.0",
+                        "strip-ansi": "3.0.1",
+                        "supports-color": "2.0.0"
+                    },
+                    "dependencies": {
+                        "supports-color": {
+                            "version": "2.0.0",
+                            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                            "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+                            "dev": true
+                        }
+                    }
+                },
+                "has-flag": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+                    "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+                    "dev": true
+                },
+                "postcss": {
+                    "version": "5.2.18",
+                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
+                    "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+                    "dev": true,
+                    "requires": {
+                        "chalk": "1.1.3",
+                        "js-base64": "2.5.1",
+                        "source-map": "0.5.7",
+                        "supports-color": "3.2.3"
+                    }
+                },
+                "source-map": {
+                    "version": "0.5.7",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+                    "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "3.2.3",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+                    "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "1.0.0"
+                    }
+                }
+            }
+        },
+        "postcss-focus-visible": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-focus-visible/-/postcss-focus-visible-4.0.0.tgz",
+            "integrity": "sha512-Z5CkWBw0+idJHSV6+Bgf2peDOFf/x4o+vX/pwcNYrWpXFrSfTkQ3JQ1ojrq9yS+upnAlNRHeg8uEwFTgorjI8g==",
+            "dev": true,
+            "requires": {
+                "postcss": "7.0.17"
+            }
+        },
+        "postcss-focus-within": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-focus-within/-/postcss-focus-within-3.0.0.tgz",
+            "integrity": "sha512-W0APui8jQeBKbCGZudW37EeMCjDeVxKgiYfIIEo8Bdh5SpB9sxds/Iq8SEuzS0Q4YFOlG7EPFulbbxujpkrV2w==",
+            "dev": true,
+            "requires": {
+                "postcss": "7.0.17"
+            }
+        },
+        "postcss-font-variant": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-font-variant/-/postcss-font-variant-4.0.0.tgz",
+            "integrity": "sha512-M8BFYKOvCrI2aITzDad7kWuXXTm0YhGdP9Q8HanmN4EF1Hmcgs1KK5rSHylt/lUJe8yLxiSwWAHdScoEiIxztg==",
+            "dev": true,
+            "requires": {
+                "postcss": "7.0.17"
+            }
+        },
+        "postcss-gap-properties": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-gap-properties/-/postcss-gap-properties-2.0.0.tgz",
+            "integrity": "sha512-QZSqDaMgXCHuHTEzMsS2KfVDOq7ZFiknSpkrPJY6jmxbugUPTuSzs/vuE5I3zv0WAS+3vhrlqhijiprnuQfzmg==",
+            "dev": true,
+            "requires": {
+                "postcss": "7.0.17"
+            }
+        },
+        "postcss-html": {
+            "version": "0.36.0",
+            "resolved": "https://registry.npmjs.org/postcss-html/-/postcss-html-0.36.0.tgz",
+            "integrity": "sha512-HeiOxGcuwID0AFsNAL0ox3mW6MHH5cstWN1Z3Y+n6H+g12ih7LHdYxWwEA/QmrebctLjo79xz9ouK3MroHwOJw==",
+            "dev": true,
+            "requires": {
+                "htmlparser2": "3.10.1"
+            }
+        },
+        "postcss-image-set-function": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/postcss-image-set-function/-/postcss-image-set-function-3.0.1.tgz",
+            "integrity": "sha512-oPTcFFip5LZy8Y/whto91L9xdRHCWEMs3e1MdJxhgt4jy2WYXfhkng59fH5qLXSCPN8k4n94p1Czrfe5IOkKUw==",
+            "dev": true,
+            "requires": {
+                "postcss": "7.0.17",
+                "postcss-values-parser": "2.0.1"
+            }
+        },
+        "postcss-import": {
+            "version": "12.0.1",
+            "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-12.0.1.tgz",
+            "integrity": "sha512-3Gti33dmCjyKBgimqGxL3vcV8w9+bsHwO5UrBawp796+jdardbcFl4RP5w/76BwNL7aGzpKstIfF9I+kdE8pTw==",
+            "dev": true,
+            "requires": {
+                "postcss": "7.0.17",
+                "postcss-value-parser": "3.3.1",
+                "read-cache": "1.0.0",
+                "resolve": "1.11.1"
+            }
+        },
+        "postcss-initial": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/postcss-initial/-/postcss-initial-3.0.1.tgz",
+            "integrity": "sha512-I2Sz83ZSHybMNh02xQDK609lZ1/QOyYeuizCjzEhlMgeV/HcDJapQiH4yTqLjZss0X6/6VvKFXUeObaHpJoINw==",
+            "dev": true,
+            "requires": {
+                "lodash.template": "4.5.0",
+                "postcss": "7.0.17"
+            }
+        },
+        "postcss-jsx": {
+            "version": "0.36.2",
+            "resolved": "https://registry.npmjs.org/postcss-jsx/-/postcss-jsx-0.36.2.tgz",
+            "integrity": "sha512-7B8a8a6YDOQFqMQ9UmOo+IPPb2i14Z57Fvc9cOI11B3bWMSY2O6r2XJ3tlcQhUhv93TeN0ntxehTaSWJDQavlg==",
+            "dev": true,
+            "requires": {
+                "@babel/core": "7.5.5"
+            }
+        },
+        "postcss-lab-function": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/postcss-lab-function/-/postcss-lab-function-2.0.1.tgz",
+            "integrity": "sha512-whLy1IeZKY+3fYdqQFuDBf8Auw+qFuVnChWjmxm/UhHWqNHZx+B99EwxTvGYmUBqe3Fjxs4L1BoZTJmPu6usVg==",
+            "dev": true,
+            "requires": {
+                "@csstools/convert-colors": "1.4.0",
+                "postcss": "7.0.17",
+                "postcss-values-parser": "2.0.1"
+            }
+        },
+        "postcss-less": {
+            "version": "3.1.4",
+            "resolved": "https://registry.npmjs.org/postcss-less/-/postcss-less-3.1.4.tgz",
+            "integrity": "sha512-7TvleQWNM2QLcHqvudt3VYjULVB49uiW6XzEUFmvwHzvsOEF5MwBrIXZDJQvJNFGjJQTzSzZnDoCJ8h/ljyGXA==",
+            "dev": true,
+            "requires": {
+                "postcss": "7.0.17"
+            }
+        },
+        "postcss-load-config": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-2.1.0.tgz",
+            "integrity": "sha512-4pV3JJVPLd5+RueiVVB+gFOAa7GWc25XQcMp86Zexzke69mKf6Nx9LRcQywdz7yZI9n1udOxmLuAwTBypypF8Q==",
+            "dev": true,
+            "requires": {
+                "cosmiconfig": "5.2.1",
+                "import-cwd": "2.1.0"
+            }
+        },
+        "postcss-loader": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-loader/-/postcss-loader-3.0.0.tgz",
+            "integrity": "sha512-cLWoDEY5OwHcAjDnkyRQzAXfs2jrKjXpO/HQFcc5b5u/r7aa471wdmChmwfnv7x2u840iat/wi0lQ5nbRgSkUA==",
+            "dev": true,
+            "requires": {
+                "loader-utils": "1.2.3",
+                "postcss": "7.0.17",
+                "postcss-load-config": "2.1.0",
+                "schema-utils": "1.0.0"
+            }
+        },
+        "postcss-logical": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-logical/-/postcss-logical-3.0.0.tgz",
+            "integrity": "sha512-1SUKdJc2vuMOmeItqGuNaC+N8MzBWFWEkAnRnLpFYj1tGGa7NqyVBujfRtgNa2gXR+6RkGUiB2O5Vmh7E2RmiA==",
+            "dev": true,
+            "requires": {
+                "postcss": "7.0.17"
+            }
+        },
+        "postcss-markdown": {
+            "version": "0.36.0",
+            "resolved": "https://registry.npmjs.org/postcss-markdown/-/postcss-markdown-0.36.0.tgz",
+            "integrity": "sha512-rl7fs1r/LNSB2bWRhyZ+lM/0bwKv9fhl38/06gF6mKMo/NPnp55+K1dSTosSVjFZc0e1ppBlu+WT91ba0PMBfQ==",
+            "dev": true,
+            "requires": {
+                "remark": "10.0.1",
+                "unist-util-find-all-after": "1.0.4"
+            }
+        },
+        "postcss-media-minmax": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-media-minmax/-/postcss-media-minmax-4.0.0.tgz",
+            "integrity": "sha512-fo9moya6qyxsjbFAYl97qKO9gyre3qvbMnkOZeZwlsW6XYFsvs2DMGDlchVLfAd8LHPZDxivu/+qW2SMQeTHBw==",
+            "dev": true,
+            "requires": {
+                "postcss": "7.0.17"
+            }
+        },
+        "postcss-media-query-parser": {
+            "version": "0.2.3",
+            "resolved": "https://registry.npmjs.org/postcss-media-query-parser/-/postcss-media-query-parser-0.2.3.tgz",
+            "integrity": "sha1-J7Ocb02U+Bsac7j3Y1HGCeXO8kQ=",
+            "dev": true
+        },
+        "postcss-merge-longhand": {
+            "version": "4.0.11",
+            "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-4.0.11.tgz",
+            "integrity": "sha512-alx/zmoeXvJjp7L4mxEMjh8lxVlDFX1gqWHzaaQewwMZiVhLo42TEClKaeHbRf6J7j82ZOdTJ808RtN0ZOZwvw==",
+            "dev": true,
+            "requires": {
+                "css-color-names": "0.0.4",
+                "postcss": "7.0.17",
+                "postcss-value-parser": "3.3.1",
+                "stylehacks": "4.0.3"
+            }
+        },
+        "postcss-merge-rules": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-4.0.3.tgz",
+            "integrity": "sha512-U7e3r1SbvYzO0Jr3UT/zKBVgYYyhAz0aitvGIYOYK5CPmkNih+WDSsS5tvPrJ8YMQYlEMvsZIiqmn7HdFUaeEQ==",
+            "dev": true,
+            "requires": {
+                "browserslist": "4.6.6",
+                "caniuse-api": "3.0.0",
+                "cssnano-util-same-parent": "4.0.1",
+                "postcss": "7.0.17",
+                "postcss-selector-parser": "3.1.1",
+                "vendors": "1.0.3"
+            },
+            "dependencies": {
+                "postcss-selector-parser": {
+                    "version": "3.1.1",
+                    "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-3.1.1.tgz",
+                    "integrity": "sha1-T4dfSvsMllc9XPTXQBGu4lCn6GU=",
+                    "dev": true,
+                    "requires": {
+                        "dot-prop": "4.2.0",
+                        "indexes-of": "1.0.1",
+                        "uniq": "1.0.1"
+                    }
+                }
+            }
+        },
+        "postcss-minify-font-values": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-4.0.2.tgz",
+            "integrity": "sha512-j85oO6OnRU9zPf04+PZv1LYIYOprWm6IA6zkXkrJXyRveDEuQggG6tvoy8ir8ZwjLxLuGfNkCZEQG7zan+Hbtg==",
+            "dev": true,
+            "requires": {
+                "postcss": "7.0.17",
+                "postcss-value-parser": "3.3.1"
+            }
+        },
+        "postcss-minify-gradients": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-4.0.2.tgz",
+            "integrity": "sha512-qKPfwlONdcf/AndP1U8SJ/uzIJtowHlMaSioKzebAXSG4iJthlWC9iSWznQcX4f66gIWX44RSA841HTHj3wK+Q==",
+            "dev": true,
+            "requires": {
+                "cssnano-util-get-arguments": "4.0.0",
+                "is-color-stop": "1.1.0",
+                "postcss": "7.0.17",
+                "postcss-value-parser": "3.3.1"
+            }
+        },
+        "postcss-minify-params": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-4.0.2.tgz",
+            "integrity": "sha512-G7eWyzEx0xL4/wiBBJxJOz48zAKV2WG3iZOqVhPet/9geefm/Px5uo1fzlHu+DOjT+m0Mmiz3jkQzVHe6wxAWg==",
+            "dev": true,
+            "requires": {
+                "alphanum-sort": "1.0.2",
+                "browserslist": "4.6.6",
+                "cssnano-util-get-arguments": "4.0.0",
+                "postcss": "7.0.17",
+                "postcss-value-parser": "3.3.1",
+                "uniqs": "2.0.0"
+            }
+        },
+        "postcss-minify-selectors": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-4.0.2.tgz",
+            "integrity": "sha512-D5S1iViljXBj9kflQo4YutWnJmwm8VvIsU1GeXJGiG9j8CIg9zs4voPMdQDUmIxetUOh60VilsNzCiAFTOqu3g==",
+            "dev": true,
+            "requires": {
+                "alphanum-sort": "1.0.2",
+                "has": "1.0.3",
+                "postcss": "7.0.17",
+                "postcss-selector-parser": "3.1.1"
+            },
+            "dependencies": {
+                "postcss-selector-parser": {
+                    "version": "3.1.1",
+                    "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-3.1.1.tgz",
+                    "integrity": "sha1-T4dfSvsMllc9XPTXQBGu4lCn6GU=",
+                    "dev": true,
+                    "requires": {
+                        "dot-prop": "4.2.0",
+                        "indexes-of": "1.0.1",
+                        "uniq": "1.0.1"
+                    }
+                }
+            }
+        },
+        "postcss-modules-extract-imports": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-2.0.0.tgz",
+            "integrity": "sha512-LaYLDNS4SG8Q5WAWqIJgdHPJrDDr/Lv775rMBFUbgjTz6j34lUznACHcdRWroPvXANP2Vj7yNK57vp9eFqzLWQ==",
+            "dev": true,
+            "requires": {
+                "postcss": "7.0.17"
+            }
+        },
+        "postcss-modules-local-by-default": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-3.0.2.tgz",
+            "integrity": "sha512-jM/V8eqM4oJ/22j0gx4jrp63GSvDH6v86OqyTHHUvk4/k1vceipZsaymiZ5PvocqZOl5SFHiFJqjs3la0wnfIQ==",
+            "dev": true,
+            "requires": {
+                "icss-utils": "4.1.1",
+                "postcss": "7.0.17",
+                "postcss-selector-parser": "6.0.2",
+                "postcss-value-parser": "4.0.0"
+            },
+            "dependencies": {
+                "postcss-value-parser": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.0.0.tgz",
+                    "integrity": "sha512-ESPktioptiSUchCKgggAkzdmkgzKfmp0EU8jXH+5kbIUB+unr0Y4CY9SRMvibuvYUBjNh1ACLbxqYNpdTQOteQ==",
+                    "dev": true
+                }
+            }
+        },
+        "postcss-modules-scope": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-2.1.0.tgz",
+            "integrity": "sha512-91Rjps0JnmtUB0cujlc8KIKCsJXWjzuxGeT/+Q2i2HXKZ7nBUeF9YQTZZTNvHVoNYj1AthsjnGLtqDUE0Op79A==",
+            "dev": true,
+            "requires": {
+                "postcss": "7.0.17",
+                "postcss-selector-parser": "6.0.2"
+            }
+        },
+        "postcss-modules-values": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-3.0.0.tgz",
+            "integrity": "sha512-1//E5jCBrZ9DmRX+zCtmQtRSV6PV42Ix7Bzj9GbwJceduuf7IqP8MgeTXuRDHOWj2m0VzZD5+roFWDuU8RQjcg==",
+            "dev": true,
+            "requires": {
+                "icss-utils": "4.1.1",
+                "postcss": "7.0.17"
+            }
+        },
+        "postcss-nested": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-4.1.2.tgz",
+            "integrity": "sha512-9bQFr2TezohU3KRSu9f6sfecXmf/x6RXDedl8CHF6fyuyVW7UqgNMRdWMHZQWuFY6Xqs2NYk+Fj4Z4vSOf7PQg==",
+            "dev": true,
+            "requires": {
+                "postcss": "7.0.17",
+                "postcss-selector-parser": "5.0.0"
+            },
+            "dependencies": {
+                "cssesc": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-2.0.0.tgz",
+                    "integrity": "sha512-MsCAG1z9lPdoO/IUMLSBWBSVxVtJ1395VGIQ+Fc2gNdkQ1hNDnQdw3YhA71WJCBW1vdwA0cAnk/DnW6bqoEUYg==",
+                    "dev": true
+                },
+                "postcss-selector-parser": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-5.0.0.tgz",
+                    "integrity": "sha512-w+zLE5Jhg6Liz8+rQOWEAwtwkyqpfnmsinXjXg6cY7YIONZZtgvE0v2O0uhQBs0peNomOJwWRKt6JBfTdTd3OQ==",
+                    "dev": true,
+                    "requires": {
+                        "cssesc": "2.0.0",
+                        "indexes-of": "1.0.1",
+                        "uniq": "1.0.1"
+                    }
+                }
+            }
+        },
+        "postcss-nesting": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-nesting/-/postcss-nesting-7.0.0.tgz",
+            "integrity": "sha512-WSsbVd5Ampi3Y0nk/SKr5+K34n52PqMqEfswu6RtU4r7wA8vSD+gM8/D9qq4aJkHImwn1+9iEFTbjoWsQeqtaQ==",
+            "dev": true,
+            "requires": {
+                "postcss": "7.0.17"
+            }
+        },
+        "postcss-normalize-charset": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-4.0.1.tgz",
+            "integrity": "sha512-gMXCrrlWh6G27U0hF3vNvR3w8I1s2wOBILvA87iNXaPvSNo5uZAMYsZG7XjCUf1eVxuPfyL4TJ7++SGZLc9A3g==",
+            "dev": true,
+            "requires": {
+                "postcss": "7.0.17"
+            }
+        },
+        "postcss-normalize-display-values": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/postcss-normalize-display-values/-/postcss-normalize-display-values-4.0.2.tgz",
+            "integrity": "sha512-3F2jcsaMW7+VtRMAqf/3m4cPFhPD3EFRgNs18u+k3lTJJlVe7d0YPO+bnwqo2xg8YiRpDXJI2u8A0wqJxMsQuQ==",
+            "dev": true,
+            "requires": {
+                "cssnano-util-get-match": "4.0.0",
+                "postcss": "7.0.17",
+                "postcss-value-parser": "3.3.1"
+            }
+        },
+        "postcss-normalize-positions": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/postcss-normalize-positions/-/postcss-normalize-positions-4.0.2.tgz",
+            "integrity": "sha512-Dlf3/9AxpxE+NF1fJxYDeggi5WwV35MXGFnnoccP/9qDtFrTArZ0D0R+iKcg5WsUd8nUYMIl8yXDCtcrT8JrdA==",
+            "dev": true,
+            "requires": {
+                "cssnano-util-get-arguments": "4.0.0",
+                "has": "1.0.3",
+                "postcss": "7.0.17",
+                "postcss-value-parser": "3.3.1"
+            }
+        },
+        "postcss-normalize-repeat-style": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/postcss-normalize-repeat-style/-/postcss-normalize-repeat-style-4.0.2.tgz",
+            "integrity": "sha512-qvigdYYMpSuoFs3Is/f5nHdRLJN/ITA7huIoCyqqENJe9PvPmLhNLMu7QTjPdtnVf6OcYYO5SHonx4+fbJE1+Q==",
+            "dev": true,
+            "requires": {
+                "cssnano-util-get-arguments": "4.0.0",
+                "cssnano-util-get-match": "4.0.0",
+                "postcss": "7.0.17",
+                "postcss-value-parser": "3.3.1"
+            }
+        },
+        "postcss-normalize-string": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/postcss-normalize-string/-/postcss-normalize-string-4.0.2.tgz",
+            "integrity": "sha512-RrERod97Dnwqq49WNz8qo66ps0swYZDSb6rM57kN2J+aoyEAJfZ6bMx0sx/F9TIEX0xthPGCmeyiam/jXif0eA==",
+            "dev": true,
+            "requires": {
+                "has": "1.0.3",
+                "postcss": "7.0.17",
+                "postcss-value-parser": "3.3.1"
+            }
+        },
+        "postcss-normalize-timing-functions": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/postcss-normalize-timing-functions/-/postcss-normalize-timing-functions-4.0.2.tgz",
+            "integrity": "sha512-acwJY95edP762e++00Ehq9L4sZCEcOPyaHwoaFOhIwWCDfik6YvqsYNxckee65JHLKzuNSSmAdxwD2Cud1Z54A==",
+            "dev": true,
+            "requires": {
+                "cssnano-util-get-match": "4.0.0",
+                "postcss": "7.0.17",
+                "postcss-value-parser": "3.3.1"
+            }
+        },
+        "postcss-normalize-unicode": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/postcss-normalize-unicode/-/postcss-normalize-unicode-4.0.1.tgz",
+            "integrity": "sha512-od18Uq2wCYn+vZ/qCOeutvHjB5jm57ToxRaMeNuf0nWVHaP9Hua56QyMF6fs/4FSUnVIw0CBPsU0K4LnBPwYwg==",
+            "dev": true,
+            "requires": {
+                "browserslist": "4.6.6",
+                "postcss": "7.0.17",
+                "postcss-value-parser": "3.3.1"
+            }
+        },
+        "postcss-normalize-url": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-4.0.1.tgz",
+            "integrity": "sha512-p5oVaF4+IHwu7VpMan/SSpmpYxcJMtkGppYf0VbdH5B6hN8YNmVyJLuY9FmLQTzY3fag5ESUUHDqM+heid0UVA==",
+            "dev": true,
+            "requires": {
+                "is-absolute-url": "2.1.0",
+                "normalize-url": "3.3.0",
+                "postcss": "7.0.17",
+                "postcss-value-parser": "3.3.1"
+            }
+        },
+        "postcss-normalize-whitespace": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/postcss-normalize-whitespace/-/postcss-normalize-whitespace-4.0.2.tgz",
+            "integrity": "sha512-tO8QIgrsI3p95r8fyqKV+ufKlSHh9hMJqACqbv2XknufqEDhDvbguXGBBqxw9nsQoXWf0qOqppziKJKHMD4GtA==",
+            "dev": true,
+            "requires": {
+                "postcss": "7.0.17",
+                "postcss-value-parser": "3.3.1"
+            }
+        },
+        "postcss-ordered-values": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-4.1.2.tgz",
+            "integrity": "sha512-2fCObh5UanxvSxeXrtLtlwVThBvHn6MQcu4ksNT2tsaV2Fg76R2CV98W7wNSlX+5/pFwEyaDwKLLoEV7uRybAw==",
+            "dev": true,
+            "requires": {
+                "cssnano-util-get-arguments": "4.0.0",
+                "postcss": "7.0.17",
+                "postcss-value-parser": "3.3.1"
+            }
+        },
+        "postcss-overflow-shorthand": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-overflow-shorthand/-/postcss-overflow-shorthand-2.0.0.tgz",
+            "integrity": "sha512-aK0fHc9CBNx8jbzMYhshZcEv8LtYnBIRYQD5i7w/K/wS9c2+0NSR6B3OVMu5y0hBHYLcMGjfU+dmWYNKH0I85g==",
+            "dev": true,
+            "requires": {
+                "postcss": "7.0.17"
+            }
+        },
+        "postcss-page-break": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-page-break/-/postcss-page-break-2.0.0.tgz",
+            "integrity": "sha512-tkpTSrLpfLfD9HvgOlJuigLuk39wVTbbd8RKcy8/ugV2bNBUW3xU+AIqyxhDrQr1VUj1RmyJrBn1YWrqUm9zAQ==",
+            "dev": true,
+            "requires": {
+                "postcss": "7.0.17"
+            }
+        },
+        "postcss-place": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/postcss-place/-/postcss-place-4.0.1.tgz",
+            "integrity": "sha512-Zb6byCSLkgRKLODj/5mQugyuj9bvAAw9LqJJjgwz5cYryGeXfFZfSXoP1UfveccFmeq0b/2xxwcTEVScnqGxBg==",
+            "dev": true,
+            "requires": {
+                "postcss": "7.0.17",
+                "postcss-values-parser": "2.0.1"
+            }
+        },
+        "postcss-preset-env": {
+            "version": "6.7.0",
+            "resolved": "https://registry.npmjs.org/postcss-preset-env/-/postcss-preset-env-6.7.0.tgz",
+            "integrity": "sha512-eU4/K5xzSFwUFJ8hTdTQzo2RBLbDVt83QZrAvI07TULOkmyQlnYlpwep+2yIK+K+0KlZO4BvFcleOCCcUtwchg==",
+            "dev": true,
+            "requires": {
+                "autoprefixer": "9.6.1",
+                "browserslist": "4.6.6",
+                "caniuse-lite": "1.0.30000985",
+                "css-blank-pseudo": "0.1.4",
+                "css-has-pseudo": "0.10.0",
+                "css-prefers-color-scheme": "3.1.1",
+                "cssdb": "4.4.0",
+                "postcss": "7.0.17",
+                "postcss-attribute-case-insensitive": "4.0.1",
+                "postcss-color-functional-notation": "2.0.1",
+                "postcss-color-gray": "5.0.0",
+                "postcss-color-hex-alpha": "5.0.3",
+                "postcss-color-mod-function": "3.0.3",
+                "postcss-color-rebeccapurple": "4.0.1",
+                "postcss-custom-media": "7.0.8",
+                "postcss-custom-properties": "8.0.11",
+                "postcss-custom-selectors": "5.1.2",
+                "postcss-dir-pseudo-class": "5.0.0",
+                "postcss-double-position-gradients": "1.0.0",
+                "postcss-env-function": "2.0.2",
+                "postcss-focus-visible": "4.0.0",
+                "postcss-focus-within": "3.0.0",
+                "postcss-font-variant": "4.0.0",
+                "postcss-gap-properties": "2.0.0",
+                "postcss-image-set-function": "3.0.1",
+                "postcss-initial": "3.0.1",
+                "postcss-lab-function": "2.0.1",
+                "postcss-logical": "3.0.0",
+                "postcss-media-minmax": "4.0.0",
+                "postcss-nesting": "7.0.0",
+                "postcss-overflow-shorthand": "2.0.0",
+                "postcss-page-break": "2.0.0",
+                "postcss-place": "4.0.1",
+                "postcss-pseudo-class-any-link": "6.0.0",
+                "postcss-replace-overflow-wrap": "3.0.0",
+                "postcss-selector-matches": "4.0.0",
+                "postcss-selector-not": "4.0.0"
+            }
+        },
+        "postcss-pseudo-class-any-link": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-pseudo-class-any-link/-/postcss-pseudo-class-any-link-6.0.0.tgz",
+            "integrity": "sha512-lgXW9sYJdLqtmw23otOzrtbDXofUdfYzNm4PIpNE322/swES3VU9XlXHeJS46zT2onFO7V1QFdD4Q9LiZj8mew==",
+            "dev": true,
+            "requires": {
+                "postcss": "7.0.17",
+                "postcss-selector-parser": "5.0.0"
+            },
+            "dependencies": {
+                "cssesc": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-2.0.0.tgz",
+                    "integrity": "sha512-MsCAG1z9lPdoO/IUMLSBWBSVxVtJ1395VGIQ+Fc2gNdkQ1hNDnQdw3YhA71WJCBW1vdwA0cAnk/DnW6bqoEUYg==",
+                    "dev": true
+                },
+                "postcss-selector-parser": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-5.0.0.tgz",
+                    "integrity": "sha512-w+zLE5Jhg6Liz8+rQOWEAwtwkyqpfnmsinXjXg6cY7YIONZZtgvE0v2O0uhQBs0peNomOJwWRKt6JBfTdTd3OQ==",
+                    "dev": true,
+                    "requires": {
+                        "cssesc": "2.0.0",
+                        "indexes-of": "1.0.1",
+                        "uniq": "1.0.1"
+                    }
+                }
+            }
+        },
+        "postcss-reduce-initial": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-4.0.3.tgz",
+            "integrity": "sha512-gKWmR5aUulSjbzOfD9AlJiHCGH6AEVLaM0AV+aSioxUDd16qXP1PCh8d1/BGVvpdWn8k/HiK7n6TjeoXN1F7DA==",
+            "dev": true,
+            "requires": {
+                "browserslist": "4.6.6",
+                "caniuse-api": "3.0.0",
+                "has": "1.0.3",
+                "postcss": "7.0.17"
+            }
+        },
+        "postcss-reduce-transforms": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-4.0.2.tgz",
+            "integrity": "sha512-EEVig1Q2QJ4ELpJXMZR8Vt5DQx8/mo+dGWSR7vWXqcob2gQLyQGsionYcGKATXvQzMPn6DSN1vTN7yFximdIAg==",
+            "dev": true,
+            "requires": {
+                "cssnano-util-get-match": "4.0.0",
+                "has": "1.0.3",
+                "postcss": "7.0.17",
+                "postcss-value-parser": "3.3.1"
+            }
+        },
+        "postcss-remove-root": {
+            "version": "0.0.2",
+            "resolved": "https://registry.npmjs.org/postcss-remove-root/-/postcss-remove-root-0.0.2.tgz",
+            "integrity": "sha1-GdTzhdEGRCsDwreNZKo6bWdXZG0=",
+            "dev": true,
+            "requires": {
+                "postcss": "5.2.18"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "2.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+                    "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+                    "dev": true
+                },
+                "chalk": {
+                    "version": "1.1.3",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                    "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "2.2.1",
+                        "escape-string-regexp": "1.0.5",
+                        "has-ansi": "2.0.0",
+                        "strip-ansi": "3.0.1",
+                        "supports-color": "2.0.0"
+                    },
+                    "dependencies": {
+                        "supports-color": {
+                            "version": "2.0.0",
+                            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                            "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+                            "dev": true
+                        }
+                    }
+                },
+                "has-flag": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+                    "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+                    "dev": true
+                },
+                "postcss": {
+                    "version": "5.2.18",
+                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
+                    "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+                    "dev": true,
+                    "requires": {
+                        "chalk": "1.1.3",
+                        "js-base64": "2.5.1",
+                        "source-map": "0.5.7",
+                        "supports-color": "3.2.3"
+                    }
+                },
+                "source-map": {
+                    "version": "0.5.7",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+                    "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "3.2.3",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+                    "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "1.0.0"
+                    }
+                }
+            }
+        },
+        "postcss-replace-overflow-wrap": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-replace-overflow-wrap/-/postcss-replace-overflow-wrap-3.0.0.tgz",
+            "integrity": "sha512-2T5hcEHArDT6X9+9dVSPQdo7QHzG4XKclFT8rU5TzJPDN7RIRTbO9c4drUISOVemLj03aezStHCR2AIcr8XLpw==",
+            "dev": true,
+            "requires": {
+                "postcss": "7.0.17"
+            }
+        },
+        "postcss-reporter": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/postcss-reporter/-/postcss-reporter-6.0.1.tgz",
+            "integrity": "sha512-LpmQjfRWyabc+fRygxZjpRxfhRf9u/fdlKf4VHG4TSPbV2XNsuISzYW1KL+1aQzx53CAppa1bKG4APIB/DOXXw==",
+            "dev": true,
+            "requires": {
+                "chalk": "2.4.2",
+                "lodash": "4.17.15",
+                "log-symbols": "2.2.0",
+                "postcss": "7.0.17"
+            }
+        },
+        "postcss-resolve-nested-selector": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/postcss-resolve-nested-selector/-/postcss-resolve-nested-selector-0.1.1.tgz",
+            "integrity": "sha1-Kcy8fDfe36wwTp//C/FZaz9qDk4=",
+            "dev": true
+        },
+        "postcss-safe-parser": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-4.0.1.tgz",
+            "integrity": "sha512-xZsFA3uX8MO3yAda03QrG3/Eg1LN3EPfjjf07vke/46HERLZyHrTsQ9E1r1w1W//fWEhtYNndo2hQplN2cVpCQ==",
+            "dev": true,
+            "requires": {
+                "postcss": "7.0.17"
+            }
+        },
+        "postcss-sass": {
+            "version": "0.3.5",
+            "resolved": "https://registry.npmjs.org/postcss-sass/-/postcss-sass-0.3.5.tgz",
+            "integrity": "sha512-B5z2Kob4xBxFjcufFnhQ2HqJQ2y/Zs/ic5EZbCywCkxKd756Q40cIQ/veRDwSrw1BF6+4wUgmpm0sBASqVi65A==",
+            "dev": true,
+            "requires": {
+                "gonzales-pe": "4.2.4",
+                "postcss": "7.0.17"
+            }
+        },
+        "postcss-scss": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-2.0.0.tgz",
+            "integrity": "sha512-um9zdGKaDZirMm+kZFKKVsnKPF7zF7qBAtIfTSnZXD1jZ0JNZIxdB6TxQOjCnlSzLRInVl2v3YdBh/M881C4ug==",
+            "dev": true,
+            "requires": {
+                "postcss": "7.0.17"
+            }
+        },
+        "postcss-selector-matches": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-selector-matches/-/postcss-selector-matches-4.0.0.tgz",
+            "integrity": "sha512-LgsHwQR/EsRYSqlwdGzeaPKVT0Ml7LAT6E75T8W8xLJY62CE4S/l03BWIt3jT8Taq22kXP08s2SfTSzaraoPww==",
+            "dev": true,
+            "requires": {
+                "balanced-match": "1.0.0",
+                "postcss": "7.0.17"
+            }
+        },
+        "postcss-selector-not": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-selector-not/-/postcss-selector-not-4.0.0.tgz",
+            "integrity": "sha512-W+bkBZRhqJaYN8XAnbbZPLWMvZD1wKTu0UxtFKdhtGjWYmxhkUneoeOhRJKdAE5V7ZTlnbHfCR+6bNwK9e1dTQ==",
+            "dev": true,
+            "requires": {
+                "balanced-match": "1.0.0",
+                "postcss": "7.0.17"
+            }
+        },
+        "postcss-selector-parser": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.2.tgz",
+            "integrity": "sha512-36P2QR59jDTOAiIkqEprfJDsoNrvwFei3eCqKd1Y0tUsBimsq39BLp7RD+JWny3WgB1zGhJX8XVePwm9k4wdBg==",
+            "dev": true,
+            "requires": {
+                "cssesc": "3.0.0",
+                "indexes-of": "1.0.1",
+                "uniq": "1.0.1"
+            }
+        },
+        "postcss-svgo": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-4.0.2.tgz",
+            "integrity": "sha512-C6wyjo3VwFm0QgBy+Fu7gCYOkCmgmClghO+pjcxvrcBKtiKt0uCF+hvbMO1fyv5BMImRK90SMb+dwUnfbGd+jw==",
+            "dev": true,
+            "requires": {
+                "is-svg": "3.0.0",
+                "postcss": "7.0.17",
+                "postcss-value-parser": "3.3.1",
+                "svgo": "1.3.0"
+            }
+        },
+        "postcss-syntax": {
+            "version": "0.36.2",
+            "resolved": "https://registry.npmjs.org/postcss-syntax/-/postcss-syntax-0.36.2.tgz",
+            "integrity": "sha512-nBRg/i7E3SOHWxF3PpF5WnJM/jQ1YpY9000OaVXlAQj6Zp/kIqJxEDWIZ67tAd7NLuk7zqN4yqe9nc0oNAOs1w==",
+            "dev": true
+        },
+        "postcss-unique-selectors": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-4.0.1.tgz",
+            "integrity": "sha512-+JanVaryLo9QwZjKrmJgkI4Fn8SBgRO6WXQBJi7KiAVPlmxikB5Jzc4EvXMT2H0/m0RjrVVm9rGNhZddm/8Spg==",
+            "dev": true,
+            "requires": {
+                "alphanum-sort": "1.0.2",
+                "postcss": "7.0.17",
+                "uniqs": "2.0.0"
+            }
+        },
+        "postcss-value-parser": {
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+            "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
+            "dev": true
+        },
+        "postcss-values-parser": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/postcss-values-parser/-/postcss-values-parser-2.0.1.tgz",
+            "integrity": "sha512-2tLuBsA6P4rYTNKCXYG/71C7j1pU6pK503suYOmn4xYrQIzW+opD+7FAFNuGSdZC/3Qfy334QbeMu7MEb8gOxg==",
+            "dev": true,
+            "requires": {
+                "flatten": "1.0.2",
+                "indexes-of": "1.0.1",
+                "uniq": "1.0.1"
+            }
+        },
+        "prelude-ls": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+            "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+            "dev": true
+        },
+        "prepend-http": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
+            "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
+            "dev": true
+        },
+        "pretty-error": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/pretty-error/-/pretty-error-2.1.1.tgz",
+            "integrity": "sha1-X0+HyPkeWuPzuoerTPXgOxoX8aM=",
+            "dev": true,
+            "requires": {
+                "renderkid": "2.0.3",
+                "utila": "0.4.0"
+            }
+        },
+        "private": {
+            "version": "0.1.8",
+            "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
+            "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==",
+            "dev": true
+        },
+        "process": {
+            "version": "0.11.10",
+            "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+            "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
+        },
+        "process-nextick-args": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+            "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+            "dev": true
+        },
+        "progress": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+            "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+            "dev": true
+        },
+        "promise-inflight": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
+            "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
+            "dev": true
+        },
+        "prop-types": {
+            "version": "15.7.2",
+            "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+            "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+            "requires": {
+                "loose-envify": "1.4.0",
+                "object-assign": "4.1.1",
+                "react-is": "16.8.6"
+            }
+        },
+        "proxy-addr": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.5.tgz",
+            "integrity": "sha512-t/7RxHXPH6cJtP0pRG6smSr9QJidhB+3kXu0KgXnbGYMgzEnUxRQ4/LDdfOwZEMyIh3/xHb8PX3t+lfL9z+YVQ==",
+            "dev": true,
+            "requires": {
+                "forwarded": "0.1.2",
+                "ipaddr.js": "1.9.0"
+            }
+        },
+        "prr": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
+            "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
+            "dev": true
+        },
+        "public-encrypt": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.3.tgz",
+            "integrity": "sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==",
+            "dev": true,
+            "requires": {
+                "bn.js": "4.11.8",
+                "browserify-rsa": "4.0.1",
+                "create-hash": "1.2.0",
+                "parse-asn1": "5.1.4",
+                "randombytes": "2.1.0",
+                "safe-buffer": "5.1.2"
+            }
+        },
+        "pump": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+            "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+            "dev": true,
+            "requires": {
+                "end-of-stream": "1.4.1",
+                "once": "1.4.0"
+            }
+        },
+        "pumpify": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.5.1.tgz",
+            "integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
+            "dev": true,
+            "requires": {
+                "duplexify": "3.7.1",
+                "inherits": "2.0.4",
+                "pump": "2.0.1"
+            },
+            "dependencies": {
+                "pump": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
+                    "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
+                    "dev": true,
+                    "requires": {
+                        "end-of-stream": "1.4.1",
+                        "once": "1.4.0"
+                    }
+                }
+            }
+        },
+        "punycode": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+            "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+            "dev": true
+        },
+        "q": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
+            "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
+            "dev": true
+        },
+        "qs": {
+            "version": "6.7.0",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
+            "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==",
+            "dev": true
+        },
+        "query-string": {
+            "version": "4.3.4",
+            "resolved": "https://registry.npmjs.org/query-string/-/query-string-4.3.4.tgz",
+            "integrity": "sha1-u7aTucqRXCMlFbIosaArYJBD2+s=",
+            "dev": true,
+            "requires": {
+                "object-assign": "4.1.1",
+                "strict-uri-encode": "1.1.0"
+            }
+        },
+        "querystring": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+            "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
+            "dev": true
+        },
+        "querystring-es3": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
+            "integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM=",
+            "dev": true
+        },
+        "querystringify": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.1.1.tgz",
+            "integrity": "sha512-w7fLxIRCRT7U8Qu53jQnJyPkYZIaR4n5151KMfcJlO/A9397Wxb1amJvROTK6TOnp7PfoAmg/qXiNHI+08jRfA==",
+            "dev": true
+        },
+        "quick-lru": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-1.1.0.tgz",
+            "integrity": "sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g=",
+            "dev": true
+        },
+        "randombytes": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+            "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+            "dev": true,
+            "requires": {
+                "safe-buffer": "5.1.2"
+            }
+        },
+        "randomfill": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz",
+            "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
+            "dev": true,
+            "requires": {
+                "randombytes": "2.1.0",
+                "safe-buffer": "5.1.2"
+            }
+        },
+        "range-parser": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+            "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+            "dev": true
+        },
+        "raw-body": {
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.0.tgz",
+            "integrity": "sha512-4Oz8DUIwdvoa5qMJelxipzi/iJIi40O5cGV1wNYp5hvZP8ZN0T+jiNkL0QepXs+EsQ9XJ8ipEDoiH70ySUJP3Q==",
+            "dev": true,
+            "requires": {
+                "bytes": "3.1.0",
+                "http-errors": "1.7.2",
+                "iconv-lite": "0.4.24",
+                "unpipe": "1.0.0"
+            },
+            "dependencies": {
+                "bytes": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
+                    "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==",
+                    "dev": true
+                }
+            }
+        },
+        "react": {
+            "version": "16.8.6",
+            "resolved": "https://registry.npmjs.org/react/-/react-16.8.6.tgz",
+            "integrity": "sha512-pC0uMkhLaHm11ZSJULfOBqV4tIZkx87ZLvbbQYunNixAAvjnC+snJCg0XQXn9VIsttVsbZP/H/ewzgsd5fxKXw==",
+            "requires": {
+                "loose-envify": "1.4.0",
+                "object-assign": "4.1.1",
+                "prop-types": "15.7.2",
+                "scheduler": "0.13.6"
+            }
+        },
+        "react-dom": {
+            "version": "16.8.6",
+            "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.8.6.tgz",
+            "integrity": "sha512-1nL7PIq9LTL3fthPqwkvr2zY7phIPjYrT0jp4HjyEQrEROnw4dG41VVwi/wfoCneoleqrNX7iAD+pXebJZwrwA==",
+            "requires": {
+                "loose-envify": "1.4.0",
+                "object-assign": "4.1.1",
+                "prop-types": "15.7.2",
+                "scheduler": "0.13.6"
+            }
+        },
+        "react-hot-loader": {
+            "version": "4.12.9",
+            "resolved": "https://registry.npmjs.org/react-hot-loader/-/react-hot-loader-4.12.9.tgz",
+            "integrity": "sha512-lWT3JpWUN7nGHSoI9c4MV+42ov79bd8aqwDzhoyKev3owIh+hbEivT6Mb81lCV6tWuqm9trKo2/Th2/YDhFCdw==",
+            "requires": {
+                "fast-levenshtein": "2.0.6",
+                "global": "4.4.0",
+                "hoist-non-react-statics": "3.3.0",
+                "loader-utils": "1.2.3",
+                "prop-types": "15.7.2",
+                "react-lifecycles-compat": "3.0.4",
+                "shallowequal": "1.1.0",
+                "source-map": "0.7.3"
+            }
+        },
+        "react-is": {
+            "version": "16.8.6",
+            "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.6.tgz",
+            "integrity": "sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA=="
+        },
+        "react-lifecycles-compat": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
+            "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
+        },
+        "react-router": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.0.1.tgz",
+            "integrity": "sha512-EM7suCPNKb1NxcTZ2LEOWFtQBQRQXecLxVpdsP4DW4PbbqYWeRiLyV/Tt1SdCrvT2jcyXAXmVTmzvSzrPR63Bg==",
+            "requires": {
+                "@babel/runtime": "7.5.5",
+                "history": "4.9.0",
+                "hoist-non-react-statics": "3.3.0",
+                "loose-envify": "1.4.0",
+                "mini-create-react-context": "0.3.2",
+                "path-to-regexp": "1.7.0",
+                "prop-types": "15.7.2",
+                "react-is": "16.8.6",
+                "tiny-invariant": "1.0.6",
+                "tiny-warning": "1.0.3"
+            }
+        },
+        "react-router-dom": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.0.1.tgz",
+            "integrity": "sha512-zaVHSy7NN0G91/Bz9GD4owex5+eop+KvgbxXsP/O+iW1/Ln+BrJ8QiIR5a6xNPtrdTvLkxqlDClx13QO1uB8CA==",
+            "requires": {
+                "@babel/runtime": "7.5.5",
+                "history": "4.9.0",
+                "loose-envify": "1.4.0",
+                "prop-types": "15.7.2",
+                "react-router": "5.0.1",
+                "tiny-invariant": "1.0.6",
+                "tiny-warning": "1.0.3"
+            }
+        },
+        "read-cache": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
+            "integrity": "sha1-5mTvMRYRZsl1HNvo28+GtftY93Q=",
+            "dev": true,
+            "requires": {
+                "pify": "2.3.0"
+            },
+            "dependencies": {
+                "pify": {
+                    "version": "2.3.0",
+                    "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+                    "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+                    "dev": true
+                }
+            }
+        },
+        "read-pkg": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
+            "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+            "dev": true,
+            "requires": {
+                "load-json-file": "2.0.0",
+                "normalize-package-data": "2.5.0",
+                "path-type": "2.0.0"
+            }
+        },
+        "read-pkg-up": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+            "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+            "dev": true,
+            "requires": {
+                "find-up": "2.1.0",
+                "read-pkg": "2.0.0"
+            },
+            "dependencies": {
+                "find-up": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+                    "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+                    "dev": true,
+                    "requires": {
+                        "locate-path": "2.0.0"
+                    }
+                },
+                "locate-path": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+                    "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+                    "dev": true,
+                    "requires": {
+                        "p-locate": "2.0.0",
+                        "path-exists": "3.0.0"
+                    }
+                },
+                "p-limit": {
+                    "version": "1.3.0",
+                    "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+                    "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+                    "dev": true,
+                    "requires": {
+                        "p-try": "1.0.0"
+                    }
+                },
+                "p-locate": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+                    "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+                    "dev": true,
+                    "requires": {
+                        "p-limit": "1.3.0"
+                    }
+                },
+                "p-try": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+                    "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+                    "dev": true
+                }
+            }
+        },
+        "readable-stream": {
+            "version": "3.4.0",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+            "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
+            "dev": true,
+            "requires": {
+                "inherits": "2.0.4",
+                "string_decoder": "1.2.0",
+                "util-deprecate": "1.0.2"
+            }
+        },
+        "readdirp": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
+            "integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "4.2.0",
+                "micromatch": "3.1.10",
+                "readable-stream": "2.3.6"
+            },
+            "dependencies": {
+                "isarray": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                    "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+                    "dev": true
+                },
+                "readable-stream": {
+                    "version": "2.3.6",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+                    "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+                    "dev": true,
+                    "requires": {
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.4",
+                        "isarray": "1.0.0",
+                        "process-nextick-args": "2.0.1",
+                        "safe-buffer": "5.1.2",
+                        "string_decoder": "1.1.1",
+                        "util-deprecate": "1.0.2"
+                    }
+                },
+                "string_decoder": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+                    "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+                    "dev": true,
+                    "requires": {
+                        "safe-buffer": "5.1.2"
+                    }
+                }
+            }
+        },
+        "recast": {
+            "version": "0.11.23",
+            "resolved": "https://registry.npmjs.org/recast/-/recast-0.11.23.tgz",
+            "integrity": "sha1-RR/TAEqx5N+bTktmN2sqIZEkYtM=",
+            "dev": true,
+            "requires": {
+                "ast-types": "0.9.6",
+                "esprima": "3.1.3",
+                "private": "0.1.8",
+                "source-map": "0.5.7"
+            },
+            "dependencies": {
+                "esprima": {
+                    "version": "3.1.3",
+                    "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
+                    "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
+                    "dev": true
+                },
+                "source-map": {
+                    "version": "0.5.7",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+                    "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+                    "dev": true
+                }
+            }
+        },
+        "redent": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/redent/-/redent-2.0.0.tgz",
+            "integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
+            "dev": true,
+            "requires": {
+                "indent-string": "3.2.0",
+                "strip-indent": "2.0.0"
+            }
+        },
+        "regenerate": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.0.tgz",
+            "integrity": "sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg==",
+            "dev": true
+        },
+        "regenerate-unicode-properties": {
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-8.1.0.tgz",
+            "integrity": "sha512-LGZzkgtLY79GeXLm8Dp0BVLdQlWICzBnJz/ipWUgo59qBaZ+BHtq51P2q1uVZlppMuUAT37SDk39qUbjTWB7bA==",
+            "dev": true,
+            "requires": {
+                "regenerate": "1.4.0"
+            }
+        },
+        "regenerator-runtime": {
+            "version": "0.13.3",
+            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
+            "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw=="
+        },
+        "regenerator-transform": {
+            "version": "0.14.1",
+            "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.14.1.tgz",
+            "integrity": "sha512-flVuee02C3FKRISbxhXl9mGzdbWUVHubl1SMaknjxkFB1/iqpJhArQUvRxOOPEc/9tAiX0BaQ28FJH10E4isSQ==",
+            "dev": true,
+            "requires": {
+                "private": "0.1.8"
+            }
+        },
+        "regex-not": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
+            "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
+            "dev": true,
+            "requires": {
+                "extend-shallow": "3.0.2",
+                "safe-regex": "1.1.0"
+            }
+        },
+        "regexp-tree": {
+            "version": "0.1.11",
+            "resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.11.tgz",
+            "integrity": "sha512-7/l/DgapVVDzZobwMCCgMlqiqyLFJ0cduo/j+3BcDJIB+yJdsYCfKuI3l/04NV+H/rfNRdPIDbXNZHM9XvQatg==",
+            "dev": true
+        },
+        "regexpp": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
+            "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
+            "dev": true
+        },
+        "regexpu-core": {
+            "version": "4.5.4",
+            "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.5.4.tgz",
+            "integrity": "sha512-BtizvGtFQKGPUcTy56o3nk1bGRp4SZOTYrDtGNlqCQufptV5IkkLN6Emw+yunAJjzf+C9FQFtvq7IoA3+oMYHQ==",
+            "dev": true,
+            "requires": {
+                "regenerate": "1.4.0",
+                "regenerate-unicode-properties": "8.1.0",
+                "regjsgen": "0.5.0",
+                "regjsparser": "0.6.0",
+                "unicode-match-property-ecmascript": "1.0.4",
+                "unicode-match-property-value-ecmascript": "1.1.0"
+            }
+        },
+        "regjsgen": {
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.5.0.tgz",
+            "integrity": "sha512-RnIrLhrXCX5ow/E5/Mh2O4e/oa1/jW0eaBKTSy3LaCj+M3Bqvm97GWDp2yUtzIs4LEn65zR2yiYGFqb2ApnzDA==",
+            "dev": true
+        },
+        "regjsparser": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.6.0.tgz",
+            "integrity": "sha512-RQ7YyokLiQBomUJuUG8iGVvkgOLxwyZM8k6d3q5SAXpg4r5TZJZigKFvC6PpD+qQ98bCDC5YelPeA3EucDoNeQ==",
+            "dev": true,
+            "requires": {
+                "jsesc": "0.5.0"
+            },
+            "dependencies": {
+                "jsesc": {
+                    "version": "0.5.0",
+                    "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+                    "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
+                    "dev": true
+                }
+            }
+        },
+        "relateurl": {
+            "version": "0.2.7",
+            "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
+            "integrity": "sha1-VNvzd+UUQKypCkzSdGANP/LYiKk=",
+            "dev": true
+        },
+        "remark": {
+            "version": "10.0.1",
+            "resolved": "https://registry.npmjs.org/remark/-/remark-10.0.1.tgz",
+            "integrity": "sha512-E6lMuoLIy2TyiokHprMjcWNJ5UxfGQjaMSMhV+f4idM625UjjK4j798+gPs5mfjzDE6vL0oFKVeZM6gZVSVrzQ==",
+            "dev": true,
+            "requires": {
+                "remark-parse": "6.0.3",
+                "remark-stringify": "6.0.4",
+                "unified": "7.1.0"
+            }
+        },
+        "remark-parse": {
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-6.0.3.tgz",
+            "integrity": "sha512-QbDXWN4HfKTUC0hHa4teU463KclLAnwpn/FBn87j9cKYJWWawbiLgMfP2Q4XwhxxuuuOxHlw+pSN0OKuJwyVvg==",
+            "dev": true,
+            "requires": {
+                "collapse-white-space": "1.0.5",
+                "is-alphabetical": "1.0.3",
+                "is-decimal": "1.0.3",
+                "is-whitespace-character": "1.0.3",
+                "is-word-character": "1.0.3",
+                "markdown-escapes": "1.0.3",
+                "parse-entities": "1.2.2",
+                "repeat-string": "1.6.1",
+                "state-toggle": "1.0.2",
+                "trim": "0.0.1",
+                "trim-trailing-lines": "1.1.2",
+                "unherit": "1.1.2",
+                "unist-util-remove-position": "1.1.3",
+                "vfile-location": "2.0.5",
+                "xtend": "4.0.2"
+            }
+        },
+        "remark-stringify": {
+            "version": "6.0.4",
+            "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-6.0.4.tgz",
+            "integrity": "sha512-eRWGdEPMVudijE/psbIDNcnJLRVx3xhfuEsTDGgH4GsFF91dVhw5nhmnBppafJ7+NWINW6C7ZwWbi30ImJzqWg==",
+            "dev": true,
+            "requires": {
+                "ccount": "1.0.4",
+                "is-alphanumeric": "1.0.0",
+                "is-decimal": "1.0.3",
+                "is-whitespace-character": "1.0.3",
+                "longest-streak": "2.0.3",
+                "markdown-escapes": "1.0.3",
+                "markdown-table": "1.1.3",
+                "mdast-util-compact": "1.0.3",
+                "parse-entities": "1.2.2",
+                "repeat-string": "1.6.1",
+                "state-toggle": "1.0.2",
+                "stringify-entities": "1.3.2",
+                "unherit": "1.1.2",
+                "xtend": "4.0.2"
+            }
+        },
+        "remove-trailing-separator": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+            "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
+            "dev": true
+        },
+        "renderkid": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/renderkid/-/renderkid-2.0.3.tgz",
+            "integrity": "sha512-z8CLQp7EZBPCwCnncgf9C4XAi3WR0dv+uWu/PjIyhhAb5d6IJ/QZqlHFprHeKT+59//V6BNUsLbvN8+2LarxGA==",
+            "dev": true,
+            "requires": {
+                "css-select": "1.2.0",
+                "dom-converter": "0.2.0",
+                "htmlparser2": "3.10.1",
+                "strip-ansi": "3.0.1",
+                "utila": "0.4.0"
+            },
+            "dependencies": {
+                "css-select": {
+                    "version": "1.2.0",
+                    "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
+                    "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
+                    "dev": true,
+                    "requires": {
+                        "boolbase": "1.0.0",
+                        "css-what": "2.1.3",
+                        "domutils": "1.5.1",
+                        "nth-check": "1.0.2"
+                    }
+                },
+                "domutils": {
+                    "version": "1.5.1",
+                    "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
+                    "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
+                    "dev": true,
+                    "requires": {
+                        "dom-serializer": "0.1.1",
+                        "domelementtype": "1.3.1"
+                    }
+                }
+            }
+        },
+        "repeat-element": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.3.tgz",
+            "integrity": "sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g==",
+            "dev": true
+        },
+        "repeat-string": {
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+            "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+            "dev": true
+        },
+        "replace-ext": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
+            "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs=",
+            "dev": true
+        },
+        "require-directory": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+            "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+            "dev": true
+        },
+        "require-main-filename": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+            "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+            "dev": true
+        },
+        "requires-port": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+            "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
+            "dev": true
+        },
+        "resolve": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.11.1.tgz",
+            "integrity": "sha512-vIpgF6wfuJOZI7KKKSP+HmiKggadPQAdsp5HiC1mvqnfp0gF1vdwgBWZIdrVft9pgqoMFQN+R7BSWZiBxx+BBw==",
+            "dev": true,
+            "requires": {
+                "path-parse": "1.0.6"
+            }
+        },
+        "resolve-cwd": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-2.0.0.tgz",
+            "integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
+            "dev": true,
+            "requires": {
+                "resolve-from": "3.0.0"
+            }
+        },
+        "resolve-dir": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-1.0.1.tgz",
+            "integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
+            "dev": true,
+            "requires": {
+                "expand-tilde": "2.0.2",
+                "global-modules": "1.0.0"
+            },
+            "dependencies": {
+                "global-modules": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
+                    "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
+                    "dev": true,
+                    "requires": {
+                        "global-prefix": "1.0.2",
+                        "is-windows": "1.0.2",
+                        "resolve-dir": "1.0.1"
+                    }
+                },
+                "global-prefix": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-1.0.2.tgz",
+                    "integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
+                    "dev": true,
+                    "requires": {
+                        "expand-tilde": "2.0.2",
+                        "homedir-polyfill": "1.0.3",
+                        "ini": "1.3.5",
+                        "is-windows": "1.0.2",
+                        "which": "1.3.1"
+                    }
+                }
+            }
+        },
+        "resolve-from": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
+            "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
+            "dev": true
+        },
+        "resolve-pathname": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/resolve-pathname/-/resolve-pathname-2.2.0.tgz",
+            "integrity": "sha512-bAFz9ld18RzJfddgrO2e/0S2O81710++chRMUxHjXOYKF6jTAMrUNZrEZ1PvV0zlhfjidm08iRPdTLPno1FuRg=="
+        },
+        "resolve-url": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
+            "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
+            "dev": true
+        },
+        "restore-cursor": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+            "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+            "dev": true,
+            "requires": {
+                "onetime": "2.0.1",
+                "signal-exit": "3.0.2"
+            }
+        },
+        "ret": {
+            "version": "0.1.15",
+            "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+            "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+            "dev": true
+        },
+        "retry": {
+            "version": "0.12.0",
+            "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+            "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=",
+            "dev": true
+        },
+        "rgb-regex": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/rgb-regex/-/rgb-regex-1.0.1.tgz",
+            "integrity": "sha1-wODWiC3w4jviVKR16O3UGRX+rrE=",
+            "dev": true
+        },
+        "rgba-regex": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/rgba-regex/-/rgba-regex-1.0.0.tgz",
+            "integrity": "sha1-QzdOLiyglosO8VI0YLfXMP8i7rM=",
+            "dev": true
+        },
+        "rimraf": {
+            "version": "2.6.3",
+            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+            "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+            "dev": true,
+            "requires": {
+                "glob": "7.1.4"
+            }
+        },
+        "ripemd160": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
+            "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
+            "dev": true,
+            "requires": {
+                "hash-base": "3.0.4",
+                "inherits": "2.0.4"
+            }
+        },
+        "run-async": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
+            "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
+            "dev": true,
+            "requires": {
+                "is-promise": "2.1.0"
+            }
+        },
+        "run-queue": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/run-queue/-/run-queue-1.0.3.tgz",
+            "integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
+            "dev": true,
+            "requires": {
+                "aproba": "1.2.0"
+            }
+        },
+        "rxjs": {
+            "version": "6.5.2",
+            "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.2.tgz",
+            "integrity": "sha512-HUb7j3kvb7p7eCUHE3FqjoDsC1xfZQ4AHFWfTKSpZ+sAhhz5X1WX0ZuUqWbzB2QhSLp3DoLUG+hMdEDKqWo2Zg==",
+            "dev": true,
+            "requires": {
+                "tslib": "1.10.0"
+            }
+        },
+        "safe-buffer": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+            "dev": true
+        },
+        "safe-regex": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+            "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
+            "dev": true,
+            "requires": {
+                "ret": "0.1.15"
+            }
+        },
+        "safer-buffer": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+            "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+            "dev": true
+        },
+        "sax": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+            "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+            "dev": true
+        },
+        "scheduler": {
+            "version": "0.13.6",
+            "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.13.6.tgz",
+            "integrity": "sha512-IWnObHt413ucAYKsD9J1QShUKkbKLQQHdxRyw73sw4FN26iWr3DY/H34xGPe4nmL1DwXyWmSWmMrA9TfQbE/XQ==",
+            "requires": {
+                "loose-envify": "1.4.0",
+                "object-assign": "4.1.1"
+            }
+        },
+        "schema-utils": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
+            "integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
+            "dev": true,
+            "requires": {
+                "ajv": "6.10.2",
+                "ajv-errors": "1.0.1",
+                "ajv-keywords": "3.4.1"
+            }
+        },
+        "select-hose": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz",
+            "integrity": "sha1-Yl2GWPhlr0Psliv8N2o3NZpJlMo=",
+            "dev": true
+        },
+        "selfsigned": {
+            "version": "1.10.4",
+            "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.4.tgz",
+            "integrity": "sha512-9AukTiDmHXGXWtWjembZ5NDmVvP2695EtpgbCsxCa68w3c88B+alqbmZ4O3hZ4VWGXeGWzEVdvqgAJD8DQPCDw==",
+            "dev": true,
+            "requires": {
+                "node-forge": "0.7.5"
+            }
+        },
+        "semver": {
+            "version": "5.7.0",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+            "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+            "dev": true
+        },
+        "send": {
+            "version": "0.17.1",
+            "resolved": "https://registry.npmjs.org/send/-/send-0.17.1.tgz",
+            "integrity": "sha512-BsVKsiGcQMFwT8UxypobUKyv7irCNRHk1T0G680vk88yf6LBByGcZJOTJCrTP2xVN6yI+XjPJcNuE3V4fT9sAg==",
+            "dev": true,
+            "requires": {
+                "debug": "2.6.9",
+                "depd": "1.1.2",
+                "destroy": "1.0.4",
+                "encodeurl": "1.0.2",
+                "escape-html": "1.0.3",
+                "etag": "1.8.1",
+                "fresh": "0.5.2",
+                "http-errors": "1.7.2",
+                "mime": "1.6.0",
+                "ms": "2.1.1",
+                "on-finished": "2.3.0",
+                "range-parser": "1.2.1",
+                "statuses": "1.5.0"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "2.6.9",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    },
+                    "dependencies": {
+                        "ms": {
+                            "version": "2.0.0",
+                            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+                            "dev": true
+                        }
+                    }
+                },
+                "mime": {
+                    "version": "1.6.0",
+                    "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+                    "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+                    "dev": true
+                },
+                "ms": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+                    "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+                    "dev": true
+                }
+            }
+        },
+        "serialize-javascript": {
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.7.0.tgz",
+            "integrity": "sha512-ke8UG8ulpFOxO8f8gRYabHQe/ZntKlcig2Mp+8+URDP1D8vJZ0KUt7LYo07q25Z/+JVSgpr/cui9PIp5H6/+nA==",
+            "dev": true
+        },
+        "serve-index": {
+            "version": "1.9.1",
+            "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.9.1.tgz",
+            "integrity": "sha1-03aNabHn2C5c4FD/9bRTvqEqkjk=",
+            "dev": true,
+            "requires": {
+                "accepts": "1.3.7",
+                "batch": "0.6.1",
+                "debug": "2.6.9",
+                "escape-html": "1.0.3",
+                "http-errors": "1.6.3",
+                "mime-types": "2.1.24",
+                "parseurl": "1.3.3"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "2.6.9",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
+                "http-errors": {
+                    "version": "1.6.3",
+                    "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+                    "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
+                    "dev": true,
+                    "requires": {
+                        "depd": "1.1.2",
+                        "inherits": "2.0.3",
+                        "setprototypeof": "1.1.0",
+                        "statuses": "1.5.0"
+                    }
+                },
+                "inherits": {
+                    "version": "2.0.3",
+                    "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                    "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+                    "dev": true
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+                    "dev": true
+                },
+                "setprototypeof": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+                    "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
+                    "dev": true
+                }
+            }
+        },
+        "serve-static": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.14.1.tgz",
+            "integrity": "sha512-JMrvUwE54emCYWlTI+hGrGv5I8dEwmco/00EvkzIIsR7MqrHonbD9pO2MOfFnpFntl7ecpZs+3mW+XbQZu9QCg==",
+            "dev": true,
+            "requires": {
+                "encodeurl": "1.0.2",
+                "escape-html": "1.0.3",
+                "parseurl": "1.3.3",
+                "send": "0.17.1"
+            }
+        },
+        "set-blocking": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+            "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+            "dev": true
+        },
+        "set-value": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
+            "integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
+            "dev": true,
+            "requires": {
+                "extend-shallow": "2.0.1",
+                "is-extendable": "0.1.1",
+                "is-plain-object": "2.0.4",
+                "split-string": "3.1.0"
+            },
+            "dependencies": {
+                "extend-shallow": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                    "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                    "dev": true,
+                    "requires": {
+                        "is-extendable": "0.1.1"
+                    }
+                }
+            }
+        },
+        "setimmediate": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+            "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
+            "dev": true
+        },
+        "setprototypeof": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
+            "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==",
+            "dev": true
+        },
+        "sha.js": {
+            "version": "2.4.11",
+            "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+            "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
+            "dev": true,
+            "requires": {
+                "inherits": "2.0.4",
+                "safe-buffer": "5.1.2"
+            }
+        },
+        "shallowequal": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
+            "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ=="
+        },
+        "shebang-command": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+            "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+            "dev": true,
+            "requires": {
+                "shebang-regex": "1.0.0"
+            }
+        },
+        "shebang-regex": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+            "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+            "dev": true
+        },
+        "signal-exit": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+            "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+            "dev": true
+        },
+        "simple-swizzle": {
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+            "integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
+            "dev": true,
+            "requires": {
+                "is-arrayish": "0.3.2"
+            },
+            "dependencies": {
+                "is-arrayish": {
+                    "version": "0.3.2",
+                    "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+                    "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
+                    "dev": true
+                }
+            }
+        },
+        "slash": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+            "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
+            "dev": true
+        },
+        "slice-ansi": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",
+            "integrity": "sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==",
+            "dev": true,
+            "requires": {
+                "ansi-styles": "3.2.1",
+                "astral-regex": "1.0.0",
+                "is-fullwidth-code-point": "2.0.0"
+            }
+        },
+        "snapdragon": {
+            "version": "0.8.2",
+            "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
+            "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
+            "dev": true,
+            "requires": {
+                "base": "0.11.2",
+                "debug": "2.6.9",
+                "define-property": "0.2.5",
+                "extend-shallow": "2.0.1",
+                "map-cache": "0.2.2",
+                "source-map": "0.5.7",
+                "source-map-resolve": "0.5.2",
+                "use": "3.1.1"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "2.6.9",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
+                "define-property": {
+                    "version": "0.2.5",
+                    "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+                    "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+                    "dev": true,
+                    "requires": {
+                        "is-descriptor": "0.1.6"
+                    }
+                },
+                "extend-shallow": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                    "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                    "dev": true,
+                    "requires": {
+                        "is-extendable": "0.1.1"
+                    }
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+                    "dev": true
+                },
+                "source-map": {
+                    "version": "0.5.7",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+                    "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+                    "dev": true
+                }
+            }
+        },
+        "snapdragon-node": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
+            "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
+            "dev": true,
+            "requires": {
+                "define-property": "1.0.0",
+                "isobject": "3.0.1",
+                "snapdragon-util": "3.0.1"
+            },
+            "dependencies": {
+                "define-property": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+                    "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+                    "dev": true,
+                    "requires": {
+                        "is-descriptor": "1.0.2"
+                    }
+                },
+                "is-accessor-descriptor": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+                    "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "6.0.2"
+                    }
+                },
+                "is-data-descriptor": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+                    "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "6.0.2"
+                    }
+                },
+                "is-descriptor": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+                    "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+                    "dev": true,
+                    "requires": {
+                        "is-accessor-descriptor": "1.0.0",
+                        "is-data-descriptor": "1.0.0",
+                        "kind-of": "6.0.2"
+                    }
+                }
+            }
+        },
+        "snapdragon-util": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
+            "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
+            "dev": true,
+            "requires": {
+                "kind-of": "3.2.2"
+            },
+            "dependencies": {
+                "kind-of": {
+                    "version": "3.2.2",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                    "dev": true,
+                    "requires": {
+                        "is-buffer": "1.1.6"
+                    }
+                }
+            }
+        },
+        "sockjs": {
+            "version": "0.3.19",
+            "resolved": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.19.tgz",
+            "integrity": "sha512-V48klKZl8T6MzatbLlzzRNhMepEys9Y4oGFpypBFFn1gLI/QQ9HtLLyWJNbPlwGLelOVOEijUbTTJeLLI59jLw==",
+            "dev": true,
+            "requires": {
+                "faye-websocket": "0.10.0",
+                "uuid": "3.3.2"
+            }
+        },
+        "sockjs-client": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.3.0.tgz",
+            "integrity": "sha512-R9jxEzhnnrdxLCNln0xg5uGHqMnkhPSTzUZH2eXcR03S/On9Yvoq2wyUZILRUhZCNVu2PmwWVoyuiPz8th8zbg==",
+            "dev": true,
+            "requires": {
+                "debug": "3.2.6",
+                "eventsource": "1.0.7",
+                "faye-websocket": "0.11.3",
+                "inherits": "2.0.4",
+                "json3": "3.3.3",
+                "url-parse": "1.4.7"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "3.2.6",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+                    "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.1.2"
+                    }
+                },
+                "faye-websocket": {
+                    "version": "0.11.3",
+                    "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.3.tgz",
+                    "integrity": "sha512-D2y4bovYpzziGgbHYtGCMjlJM36vAl/y+xUyn1C+FVx8szd1E+86KwVw6XvYSzOP8iMpm1X0I4xJD+QtUb36OA==",
+                    "dev": true,
+                    "requires": {
+                        "websocket-driver": "0.7.3"
+                    }
+                }
+            }
+        },
+        "sort-keys": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
+            "integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
+            "dev": true,
+            "requires": {
+                "is-plain-obj": "1.1.0"
+            }
+        },
+        "source-list-map": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.1.tgz",
+            "integrity": "sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw==",
+            "dev": true
+        },
+        "source-map": {
+            "version": "0.7.3",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
+            "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ=="
+        },
+        "source-map-resolve": {
+            "version": "0.5.2",
+            "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
+            "integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
+            "dev": true,
+            "requires": {
+                "atob": "2.1.2",
+                "decode-uri-component": "0.2.0",
+                "resolve-url": "0.2.1",
+                "source-map-url": "0.4.0",
+                "urix": "0.1.0"
+            }
+        },
+        "source-map-support": {
+            "version": "0.5.12",
+            "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.12.tgz",
+            "integrity": "sha512-4h2Pbvyy15EE02G+JOZpUCmqWJuqrs+sEkzewTm++BPi7Hvn/HwcqLAcNxYAyI0x13CpPPn+kMjl+hplXMHITQ==",
+            "dev": true,
+            "requires": {
+                "buffer-from": "1.1.1",
+                "source-map": "0.6.1"
+            },
+            "dependencies": {
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
+                }
+            }
+        },
+        "source-map-url": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
+            "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
+            "dev": true
+        },
+        "spdx-correct": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
+            "integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
+            "dev": true,
+            "requires": {
+                "spdx-expression-parse": "3.0.0",
+                "spdx-license-ids": "3.0.5"
+            }
+        },
+        "spdx-exceptions": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
+            "integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA==",
+            "dev": true
+        },
+        "spdx-expression-parse": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+            "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+            "dev": true,
+            "requires": {
+                "spdx-exceptions": "2.2.0",
+                "spdx-license-ids": "3.0.5"
+            }
+        },
+        "spdx-license-ids": {
+            "version": "3.0.5",
+            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
+            "integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==",
+            "dev": true
+        },
+        "spdy": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/spdy/-/spdy-4.0.0.tgz",
+            "integrity": "sha512-ot0oEGT/PGUpzf/6uk4AWLqkq+irlqHXkrdbk51oWONh3bxQmBuljxPNl66zlRRcIJStWq0QkLUCPOPjgjvU0Q==",
+            "dev": true,
+            "requires": {
+                "debug": "4.1.1",
+                "handle-thing": "2.0.0",
+                "http-deceiver": "1.2.7",
+                "select-hose": "2.0.0",
+                "spdy-transport": "3.0.0"
+            }
+        },
+        "spdy-transport": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-3.0.0.tgz",
+            "integrity": "sha512-hsLVFE5SjA6TCisWeJXFKniGGOpBgMLmerfO2aCyCU5s7nJ/rpAepqmFifv/GCbSbueEeAJJnmSQ2rKC/g8Fcw==",
+            "dev": true,
+            "requires": {
+                "debug": "4.1.1",
+                "detect-node": "2.0.4",
+                "hpack.js": "2.1.6",
+                "obuf": "1.1.2",
+                "readable-stream": "3.4.0",
+                "wbuf": "1.7.3"
+            }
+        },
+        "specificity": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/specificity/-/specificity-0.4.1.tgz",
+            "integrity": "sha512-1klA3Gi5PD1Wv9Q0wUoOQN1IWAuPu0D1U03ThXTr0cJ20+/iq2tHSDnK7Kk/0LXJ1ztUB2/1Os0wKmfyNgUQfg==",
+            "dev": true
+        },
+        "split-string": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
+            "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+            "dev": true,
+            "requires": {
+                "extend-shallow": "3.0.2"
+            }
+        },
+        "sprintf-js": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+            "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+            "dev": true
+        },
+        "ssri": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.1.tgz",
+            "integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
+            "dev": true,
+            "requires": {
+                "figgy-pudding": "3.5.1"
+            }
+        },
+        "stable": {
+            "version": "0.1.8",
+            "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
+            "integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==",
+            "dev": true
+        },
+        "state-toggle": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/state-toggle/-/state-toggle-1.0.2.tgz",
+            "integrity": "sha512-8LpelPGR0qQM4PnfLiplOQNJcIN1/r2Gy0xKB2zKnIW2YzPMt2sR4I/+gtPjhN7Svh9kw+zqEg2SFwpBO9iNiw==",
+            "dev": true
+        },
+        "static-extend": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
+            "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
+            "dev": true,
+            "requires": {
+                "define-property": "0.2.5",
+                "object-copy": "0.1.0"
+            },
+            "dependencies": {
+                "define-property": {
+                    "version": "0.2.5",
+                    "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+                    "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+                    "dev": true,
+                    "requires": {
+                        "is-descriptor": "0.1.6"
+                    }
+                }
+            }
+        },
+        "statuses": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+            "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
+            "dev": true
+        },
+        "stream-browserify": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.2.tgz",
+            "integrity": "sha512-nX6hmklHs/gr2FuxYDltq8fJA1GDlxKQCz8O/IM4atRqBH8OORmBNgfvW5gG10GT/qQ9u0CzIvr2X5Pkt6ntqg==",
+            "dev": true,
+            "requires": {
+                "inherits": "2.0.4",
+                "readable-stream": "2.3.6"
+            },
+            "dependencies": {
+                "isarray": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                    "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+                    "dev": true
+                },
+                "readable-stream": {
+                    "version": "2.3.6",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+                    "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+                    "dev": true,
+                    "requires": {
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.4",
+                        "isarray": "1.0.0",
+                        "process-nextick-args": "2.0.1",
+                        "safe-buffer": "5.1.2",
+                        "string_decoder": "1.1.1",
+                        "util-deprecate": "1.0.2"
+                    }
+                },
+                "string_decoder": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+                    "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+                    "dev": true,
+                    "requires": {
+                        "safe-buffer": "5.1.2"
+                    }
+                }
+            }
+        },
+        "stream-each": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/stream-each/-/stream-each-1.2.3.tgz",
+            "integrity": "sha512-vlMC2f8I2u/bZGqkdfLQW/13Zihpej/7PmSiMQsbYddxuTsJp8vRe2x2FvVExZg7FaOds43ROAuFJwPR4MTZLw==",
+            "dev": true,
+            "requires": {
+                "end-of-stream": "1.4.1",
+                "stream-shift": "1.0.0"
+            }
+        },
+        "stream-http": {
+            "version": "2.8.3",
+            "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.8.3.tgz",
+            "integrity": "sha512-+TSkfINHDo4J+ZobQLWiMouQYB+UVYFttRA94FpEzzJ7ZdqcL4uUUQ7WkdkI4DSozGmgBUE/a47L+38PenXhUw==",
+            "dev": true,
+            "requires": {
+                "builtin-status-codes": "3.0.0",
+                "inherits": "2.0.4",
+                "readable-stream": "2.3.6",
+                "to-arraybuffer": "1.0.1",
+                "xtend": "4.0.2"
+            },
+            "dependencies": {
+                "isarray": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                    "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+                    "dev": true
+                },
+                "readable-stream": {
+                    "version": "2.3.6",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+                    "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+                    "dev": true,
+                    "requires": {
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.4",
+                        "isarray": "1.0.0",
+                        "process-nextick-args": "2.0.1",
+                        "safe-buffer": "5.1.2",
+                        "string_decoder": "1.1.1",
+                        "util-deprecate": "1.0.2"
+                    }
+                },
+                "string_decoder": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+                    "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+                    "dev": true,
+                    "requires": {
+                        "safe-buffer": "5.1.2"
+                    }
+                }
+            }
+        },
+        "stream-shift": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
+            "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
+            "dev": true
+        },
+        "strict-uri-encode": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
+            "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
+            "dev": true
+        },
+        "string-width": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+            "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+            "dev": true,
+            "requires": {
+                "is-fullwidth-code-point": "2.0.0",
+                "strip-ansi": "4.0.0"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+                    "dev": true
+                },
+                "strip-ansi": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+                    "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "3.0.0"
+                    }
+                }
+            }
+        },
+        "string_decoder": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.2.0.tgz",
+            "integrity": "sha512-6YqyX6ZWEYguAxgZzHGL7SsCeGx3V2TtOTqZz1xSTSWnqsbWwbptafNyvf/ACquZUXV3DANr5BDIwNYe1mN42w==",
+            "dev": true,
+            "requires": {
+                "safe-buffer": "5.1.2"
+            }
+        },
+        "stringify-entities": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-1.3.2.tgz",
+            "integrity": "sha512-nrBAQClJAPN2p+uGCVJRPIPakKeKWZ9GtBCmormE7pWOSlHat7+x5A8gx85M7HM5Dt0BP3pP5RhVW77WdbJJ3A==",
+            "dev": true,
+            "requires": {
+                "character-entities-html4": "1.1.3",
+                "character-entities-legacy": "1.1.3",
+                "is-alphanumerical": "1.0.3",
+                "is-hexadecimal": "1.0.3"
+            }
+        },
+        "strip-ansi": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+            "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+            "dev": true,
+            "requires": {
+                "ansi-regex": "2.1.1"
+            }
+        },
+        "strip-bom": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+            "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+            "dev": true
+        },
+        "strip-eof": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+            "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
+            "dev": true
+        },
+        "strip-indent": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
+            "integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=",
+            "dev": true
+        },
+        "strip-json-comments": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.0.1.tgz",
+            "integrity": "sha512-VTyMAUfdm047mwKl+u79WIdrZxtFtn+nBxHeb844XBQ9uMNTuTHdx2hc5RiAJYqwTj3wc/xe5HLSdJSkJ+WfZw==",
+            "dev": true
+        },
+        "style-loader": {
+            "version": "0.23.1",
+            "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-0.23.1.tgz",
+            "integrity": "sha512-XK+uv9kWwhZMZ1y7mysB+zoihsEj4wneFWAS5qoiLwzW0WzSqMrrsIy+a3zkQJq0ipFtBpX5W3MqyRIBF/WFGg==",
+            "dev": true,
+            "requires": {
+                "loader-utils": "1.2.3",
+                "schema-utils": "1.0.0"
+            }
+        },
+        "style-search": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/style-search/-/style-search-0.1.0.tgz",
+            "integrity": "sha1-eVjHk+R+MuB9K1yv5cC/jhLneQI=",
+            "dev": true
+        },
+        "stylehacks": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-4.0.3.tgz",
+            "integrity": "sha512-7GlLk9JwlElY4Y6a/rmbH2MhVlTyVmiJd1PfTCqFaIBEGMYNsrO/v3SeGTdhBThLg4Z+NbOk/qFMwCa+J+3p/g==",
+            "dev": true,
+            "requires": {
+                "browserslist": "4.6.6",
+                "postcss": "7.0.17",
+                "postcss-selector-parser": "3.1.1"
+            },
+            "dependencies": {
+                "postcss-selector-parser": {
+                    "version": "3.1.1",
+                    "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-3.1.1.tgz",
+                    "integrity": "sha1-T4dfSvsMllc9XPTXQBGu4lCn6GU=",
+                    "dev": true,
+                    "requires": {
+                        "dot-prop": "4.2.0",
+                        "indexes-of": "1.0.1",
+                        "uniq": "1.0.1"
+                    }
+                }
+            }
+        },
+        "stylelint": {
+            "version": "10.1.0",
+            "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-10.1.0.tgz",
+            "integrity": "sha512-OmlUXrgzEMLQYj1JPTpyZPR9G4bl0StidfHnGJEMpdiQ0JyTq0MPg1xkHk1/xVJ2rTPESyJCDWjG8Kbpoo7Kuw==",
+            "dev": true,
+            "requires": {
+                "autoprefixer": "9.6.1",
+                "balanced-match": "1.0.0",
+                "chalk": "2.4.2",
+                "cosmiconfig": "5.2.1",
+                "debug": "4.1.1",
+                "execall": "2.0.0",
+                "file-entry-cache": "5.0.1",
+                "get-stdin": "7.0.0",
+                "global-modules": "2.0.0",
+                "globby": "9.2.0",
+                "globjoin": "0.1.4",
+                "html-tags": "3.0.0",
+                "ignore": "5.1.2",
+                "import-lazy": "4.0.0",
+                "imurmurhash": "0.1.4",
+                "known-css-properties": "0.14.0",
+                "leven": "3.1.0",
+                "lodash": "4.17.15",
+                "log-symbols": "3.0.0",
+                "mathml-tag-names": "2.1.1",
+                "meow": "5.0.0",
+                "micromatch": "4.0.2",
+                "normalize-selector": "0.2.0",
+                "pify": "4.0.1",
+                "postcss": "7.0.17",
+                "postcss-html": "0.36.0",
+                "postcss-jsx": "0.36.2",
+                "postcss-less": "3.1.4",
+                "postcss-markdown": "0.36.0",
+                "postcss-media-query-parser": "0.2.3",
+                "postcss-reporter": "6.0.1",
+                "postcss-resolve-nested-selector": "0.1.1",
+                "postcss-safe-parser": "4.0.1",
+                "postcss-sass": "0.3.5",
+                "postcss-scss": "2.0.0",
+                "postcss-selector-parser": "3.1.1",
+                "postcss-syntax": "0.36.2",
+                "postcss-value-parser": "3.3.1",
+                "resolve-from": "5.0.0",
+                "signal-exit": "3.0.2",
+                "slash": "3.0.0",
+                "specificity": "0.4.1",
+                "string-width": "4.1.0",
+                "strip-ansi": "5.2.0",
+                "style-search": "0.1.0",
+                "sugarss": "2.0.0",
+                "svg-tags": "1.0.0",
+                "table": "5.4.4"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+                    "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+                    "dev": true
+                },
+                "braces": {
+                    "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+                    "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+                    "dev": true,
+                    "requires": {
+                        "fill-range": "7.0.1"
+                    }
+                },
+                "emoji-regex": {
+                    "version": "8.0.0",
+                    "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+                    "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+                    "dev": true
+                },
+                "fill-range": {
+                    "version": "7.0.1",
+                    "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+                    "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+                    "dev": true,
+                    "requires": {
+                        "to-regex-range": "5.0.1"
+                    }
+                },
+                "ignore": {
+                    "version": "5.1.2",
+                    "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.2.tgz",
+                    "integrity": "sha512-vdqWBp7MyzdmHkkRWV5nY+PfGRbYbahfuvsBCh277tq+w9zyNi7h5CYJCK0kmzti9kU+O/cB7sE8HvKv6aXAKQ==",
+                    "dev": true
+                },
+                "is-fullwidth-code-point": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+                    "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+                    "dev": true
+                },
+                "is-number": {
+                    "version": "7.0.0",
+                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+                    "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+                    "dev": true
+                },
+                "log-symbols": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-3.0.0.tgz",
+                    "integrity": "sha512-dSkNGuI7iG3mfvDzUuYZyvk5dD9ocYCYzNU6CYDE6+Xqd+gwme6Z00NS3dUh8mq/73HaEtT7m6W+yUPtU6BZnQ==",
+                    "dev": true,
+                    "requires": {
+                        "chalk": "2.4.2"
+                    }
+                },
+                "micromatch": {
+                    "version": "4.0.2",
+                    "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+                    "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+                    "dev": true,
+                    "requires": {
+                        "braces": "3.0.2",
+                        "picomatch": "2.0.7"
+                    }
+                },
+                "postcss-selector-parser": {
+                    "version": "3.1.1",
+                    "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-3.1.1.tgz",
+                    "integrity": "sha1-T4dfSvsMllc9XPTXQBGu4lCn6GU=",
+                    "dev": true,
+                    "requires": {
+                        "dot-prop": "4.2.0",
+                        "indexes-of": "1.0.1",
+                        "uniq": "1.0.1"
+                    }
+                },
+                "resolve-from": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+                    "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+                    "dev": true
+                },
+                "slash": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+                    "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+                    "dev": true
+                },
+                "string-width": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.1.0.tgz",
+                    "integrity": "sha512-NrX+1dVVh+6Y9dnQ19pR0pP4FiEIlUvdTGn8pw6CKTNq5sgib2nIhmUNT5TAmhWmvKr3WcxBcP3E8nWezuipuQ==",
+                    "dev": true,
+                    "requires": {
+                        "emoji-regex": "8.0.0",
+                        "is-fullwidth-code-point": "3.0.0",
+                        "strip-ansi": "5.2.0"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+                    "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "4.1.0"
+                    }
+                },
+                "to-regex-range": {
+                    "version": "5.0.1",
+                    "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+                    "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+                    "dev": true,
+                    "requires": {
+                        "is-number": "7.0.0"
+                    }
+                }
+            }
+        },
+        "stylelint-config-recommended": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-2.2.0.tgz",
+            "integrity": "sha512-bZ+d4RiNEfmoR74KZtCKmsABdBJr4iXRiCso+6LtMJPw5rd/KnxUWTxht7TbafrTJK1YRjNgnN0iVZaJfc3xJA==",
+            "dev": true
+        },
+        "stylelint-config-standard": {
+            "version": "18.3.0",
+            "resolved": "https://registry.npmjs.org/stylelint-config-standard/-/stylelint-config-standard-18.3.0.tgz",
+            "integrity": "sha512-Tdc/TFeddjjy64LvjPau9SsfVRexmTFqUhnMBrzz07J4p2dVQtmpncRF/o8yZn8ugA3Ut43E6o1GtjX80TFytw==",
+            "dev": true,
+            "requires": {
+                "stylelint-config-recommended": "2.2.0"
+            }
+        },
+        "sugarss": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/sugarss/-/sugarss-2.0.0.tgz",
+            "integrity": "sha512-WfxjozUk0UVA4jm+U1d736AUpzSrNsQcIbyOkoE364GrtWmIrFdk5lksEupgWMD4VaT/0kVx1dobpiDumSgmJQ==",
+            "dev": true,
+            "requires": {
+                "postcss": "7.0.17"
+            }
+        },
+        "supports-color": {
+            "version": "5.5.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+            "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+            "dev": true,
+            "requires": {
+                "has-flag": "3.0.0"
+            }
+        },
+        "svg-tags": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/svg-tags/-/svg-tags-1.0.0.tgz",
+            "integrity": "sha1-WPcc7jvVGbWdSyqEO2x95krAR2Q=",
+            "dev": true
+        },
+        "svgo": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/svgo/-/svgo-1.3.0.tgz",
+            "integrity": "sha512-MLfUA6O+qauLDbym+mMZgtXCGRfIxyQoeH6IKVcFslyODEe/ElJNwr0FohQ3xG4C6HK6bk3KYPPXwHVJk3V5NQ==",
+            "dev": true,
+            "requires": {
+                "chalk": "2.4.2",
+                "coa": "2.0.2",
+                "css-select": "2.0.2",
+                "css-select-base-adapter": "0.1.1",
+                "css-tree": "1.0.0-alpha.33",
+                "csso": "3.5.1",
+                "js-yaml": "3.13.1",
+                "mkdirp": "0.5.1",
+                "object.values": "1.1.0",
+                "sax": "1.2.4",
+                "stable": "0.1.8",
+                "unquote": "1.1.1",
+                "util.promisify": "1.0.0"
+            }
+        },
+        "table": {
+            "version": "5.4.4",
+            "resolved": "https://registry.npmjs.org/table/-/table-5.4.4.tgz",
+            "integrity": "sha512-IIfEAUx5QlODLblLrGTTLJA7Tk0iLSGBvgY8essPRVNGHAzThujww1YqHLs6h3HfTg55h++RzLHH5Xw/rfv+mg==",
+            "dev": true,
+            "requires": {
+                "ajv": "6.10.2",
+                "lodash": "4.17.15",
+                "slice-ansi": "2.1.0",
+                "string-width": "3.1.0"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+                    "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+                    "dev": true
+                },
+                "string-width": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+                    "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+                    "dev": true,
+                    "requires": {
+                        "emoji-regex": "7.0.3",
+                        "is-fullwidth-code-point": "2.0.0",
+                        "strip-ansi": "5.2.0"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+                    "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "4.1.0"
+                    }
+                }
+            }
+        },
+        "tapable": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.3.tgz",
+            "integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==",
+            "dev": true
+        },
+        "terser": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/terser/-/terser-4.1.2.tgz",
+            "integrity": "sha512-jvNoEQSPXJdssFwqPSgWjsOrb+ELoE+ILpHPKXC83tIxOlh2U75F1KuB2luLD/3a6/7K3Vw5pDn+hvu0C4AzSw==",
+            "dev": true,
+            "requires": {
+                "commander": "2.20.0",
+                "source-map": "0.6.1",
+                "source-map-support": "0.5.12"
+            },
+            "dependencies": {
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
+                }
+            }
+        },
+        "terser-webpack-plugin": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.3.0.tgz",
+            "integrity": "sha512-W2YWmxPjjkUcOWa4pBEv4OP4er1aeQJlSo2UhtCFQCuRXEHjOFscO8VyWHj9JLlA0RzQb8Y2/Ta78XZvT54uGg==",
+            "dev": true,
+            "requires": {
+                "cacache": "11.3.3",
+                "find-cache-dir": "2.1.0",
+                "is-wsl": "1.1.0",
+                "loader-utils": "1.2.3",
+                "schema-utils": "1.0.0",
+                "serialize-javascript": "1.7.0",
+                "source-map": "0.6.1",
+                "terser": "4.1.2",
+                "webpack-sources": "1.3.0",
+                "worker-farm": "1.7.0"
+            },
+            "dependencies": {
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
+                }
+            }
+        },
+        "text-table": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+            "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+            "dev": true
+        },
+        "through": {
+            "version": "2.3.8",
+            "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+            "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+            "dev": true
+        },
+        "through2": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+            "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+            "dev": true,
+            "requires": {
+                "readable-stream": "2.3.6",
+                "xtend": "4.0.2"
+            },
+            "dependencies": {
+                "isarray": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                    "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+                    "dev": true
+                },
+                "readable-stream": {
+                    "version": "2.3.6",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+                    "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+                    "dev": true,
+                    "requires": {
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.4",
+                        "isarray": "1.0.0",
+                        "process-nextick-args": "2.0.1",
+                        "safe-buffer": "5.1.2",
+                        "string_decoder": "1.1.1",
+                        "util-deprecate": "1.0.2"
+                    }
+                },
+                "string_decoder": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+                    "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+                    "dev": true,
+                    "requires": {
+                        "safe-buffer": "5.1.2"
+                    }
+                }
+            }
+        },
+        "thunky": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.0.3.tgz",
+            "integrity": "sha512-YwT8pjmNcAXBZqrubu22P4FYsh2D4dxRmnWBOL8Jk8bUcRUtc5326kx32tuTmFDAZtLOGEVNl8POAR8j896Iow==",
+            "dev": true
+        },
+        "timers-browserify": {
+            "version": "2.0.10",
+            "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.10.tgz",
+            "integrity": "sha512-YvC1SV1XdOUaL6gx5CoGroT3Gu49pK9+TZ38ErPldOWW4j49GI1HKs9DV+KGq/w6y+LZ72W1c8cKz2vzY+qpzg==",
+            "dev": true,
+            "requires": {
+                "setimmediate": "1.0.5"
+            }
+        },
+        "timsort": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/timsort/-/timsort-0.3.0.tgz",
+            "integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q=",
+            "dev": true
+        },
+        "tiny-invariant": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.0.6.tgz",
+            "integrity": "sha512-FOyLWWVjG+aC0UqG76V53yAWdXfH8bO6FNmyZOuUrzDzK8DI3/JRY25UD7+g49JWM1LXwymsKERB+DzI0dTEQA=="
+        },
+        "tiny-warning": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
+            "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
+        },
+        "tmp": {
+            "version": "0.0.33",
+            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+            "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+            "dev": true,
+            "requires": {
+                "os-tmpdir": "1.0.2"
+            }
+        },
+        "to-arraybuffer": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
+            "integrity": "sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M=",
+            "dev": true
+        },
+        "to-fast-properties": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+            "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+            "dev": true
+        },
+        "to-object-path": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
+            "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
+            "dev": true,
+            "requires": {
+                "kind-of": "3.2.2"
+            },
+            "dependencies": {
+                "kind-of": {
+                    "version": "3.2.2",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                    "dev": true,
+                    "requires": {
+                        "is-buffer": "1.1.6"
+                    }
+                }
+            }
+        },
+        "to-regex": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
+            "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
+            "dev": true,
+            "requires": {
+                "define-property": "2.0.2",
+                "extend-shallow": "3.0.2",
+                "regex-not": "1.0.2",
+                "safe-regex": "1.1.0"
+            }
+        },
+        "to-regex-range": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+            "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+            "dev": true,
+            "requires": {
+                "is-number": "3.0.0",
+                "repeat-string": "1.6.1"
+            }
+        },
+        "toidentifier": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
+            "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==",
+            "dev": true
+        },
+        "toposort": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/toposort/-/toposort-1.0.7.tgz",
+            "integrity": "sha1-LmhELZ9k7HILjMieZEOsbKqVACk=",
+            "dev": true
+        },
+        "trim": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
+            "integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0=",
+            "dev": true
+        },
+        "trim-newlines": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-2.0.0.tgz",
+            "integrity": "sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA=",
+            "dev": true
+        },
+        "trim-right": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+            "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
+            "dev": true
+        },
+        "trim-trailing-lines": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/trim-trailing-lines/-/trim-trailing-lines-1.1.2.tgz",
+            "integrity": "sha512-MUjYItdrqqj2zpcHFTkMa9WAv4JHTI6gnRQGPFLrt5L9a6tRMiDnIqYl8JBvu2d2Tc3lWJKQwlGCp0K8AvCM+Q==",
+            "dev": true
+        },
+        "trough": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/trough/-/trough-1.0.4.tgz",
+            "integrity": "sha512-tdzBRDGWcI1OpPVmChbdSKhvSVurznZ8X36AYURAcl+0o2ldlCY2XPzyXNNxwJwwyIU+rIglTCG4kxtNKBQH7Q==",
+            "dev": true
+        },
+        "tslib": {
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
+            "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
+            "dev": true
+        },
+        "tty-browserify": {
+            "version": "0.0.0",
+            "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
+            "integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY=",
+            "dev": true
+        },
+        "type-check": {
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+            "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+            "dev": true,
+            "requires": {
+                "prelude-ls": "1.1.2"
+            }
+        },
+        "type-is": {
+            "version": "1.6.18",
+            "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+            "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+            "dev": true,
+            "requires": {
+                "media-typer": "0.3.0",
+                "mime-types": "2.1.24"
+            }
+        },
+        "typedarray": {
+            "version": "0.0.6",
+            "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+            "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+            "dev": true
+        },
+        "uglify-js": {
+            "version": "3.4.10",
+            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.10.tgz",
+            "integrity": "sha512-Y2VsbPVs0FIshJztycsO2SfPk7/KAF/T72qzv9u5EpQ4kB2hQoHlhNQTsNyy6ul7lQtqJN/AoWeS23OzEiEFxw==",
+            "dev": true,
+            "requires": {
+                "commander": "2.19.0",
+                "source-map": "0.6.1"
+            },
+            "dependencies": {
+                "commander": {
+                    "version": "2.19.0",
+                    "resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
+                    "integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==",
+                    "dev": true
+                },
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
+                }
+            }
+        },
+        "unherit": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/unherit/-/unherit-1.1.2.tgz",
+            "integrity": "sha512-W3tMnpaMG7ZY6xe/moK04U9fBhi6wEiCYHUW5Mop/wQHf12+79EQGwxYejNdhEz2mkqkBlGwm7pxmgBKMVUj0w==",
+            "dev": true,
+            "requires": {
+                "inherits": "2.0.4",
+                "xtend": "4.0.2"
+            }
+        },
+        "unicode-canonical-property-names-ecmascript": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz",
+            "integrity": "sha512-jDrNnXWHd4oHiTZnx/ZG7gtUTVp+gCcTTKr8L0HjlwphROEW3+Him+IpvC+xcJEFegapiMZyZe02CyuOnRmbnQ==",
+            "dev": true
+        },
+        "unicode-match-property-ecmascript": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-1.0.4.tgz",
+            "integrity": "sha512-L4Qoh15vTfntsn4P1zqnHulG0LdXgjSO035fEpdtp6YxXhMT51Q6vgM5lYdG/5X3MjS+k/Y9Xw4SFCY9IkR0rg==",
+            "dev": true,
+            "requires": {
+                "unicode-canonical-property-names-ecmascript": "1.0.4",
+                "unicode-property-aliases-ecmascript": "1.0.5"
+            }
+        },
+        "unicode-match-property-value-ecmascript": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.1.0.tgz",
+            "integrity": "sha512-hDTHvaBk3RmFzvSl0UVrUmC3PuW9wKVnpoUDYH0JDkSIovzw+J5viQmeYHxVSBptubnr7PbH2e0fnpDRQnQl5g==",
+            "dev": true
+        },
+        "unicode-property-aliases-ecmascript": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.0.5.tgz",
+            "integrity": "sha512-L5RAqCfXqAwR3RriF8pM0lU0w4Ryf/GgzONwi6KnL1taJQa7x1TCxdJnILX59WIGOwR57IVxn7Nej0fz1Ny6fw==",
+            "dev": true
+        },
+        "unified": {
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/unified/-/unified-7.1.0.tgz",
+            "integrity": "sha512-lbk82UOIGuCEsZhPj8rNAkXSDXd6p0QLzIuSsCdxrqnqU56St4eyOB+AlXsVgVeRmetPTYydIuvFfpDIed8mqw==",
+            "dev": true,
+            "requires": {
+                "@types/unist": "2.0.3",
+                "@types/vfile": "3.0.2",
+                "bail": "1.0.4",
+                "extend": "3.0.2",
+                "is-plain-obj": "1.1.0",
+                "trough": "1.0.4",
+                "vfile": "3.0.1",
+                "x-is-string": "0.1.0"
+            }
+        },
+        "union-value": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
+            "integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
+            "dev": true,
+            "requires": {
+                "arr-union": "3.1.0",
+                "get-value": "2.0.6",
+                "is-extendable": "0.1.1",
+                "set-value": "2.0.1"
+            }
+        },
+        "uniq": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
+            "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8=",
+            "dev": true
+        },
+        "uniqs": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz",
+            "integrity": "sha1-/+3ks2slKQaW5uFl1KWe25mOawI=",
+            "dev": true
+        },
+        "unique-filename": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.1.tgz",
+            "integrity": "sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==",
+            "dev": true,
+            "requires": {
+                "unique-slug": "2.0.2"
+            }
+        },
+        "unique-slug": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.2.tgz",
+            "integrity": "sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==",
+            "dev": true,
+            "requires": {
+                "imurmurhash": "0.1.4"
+            }
+        },
+        "unist-util-find-all-after": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/unist-util-find-all-after/-/unist-util-find-all-after-1.0.4.tgz",
+            "integrity": "sha512-CaxvMjTd+yF93BKLJvZnEfqdM7fgEACsIpQqz8vIj9CJnUb9VpyymFS3tg6TCtgrF7vfCJBF5jbT2Ox9CBRYRQ==",
+            "dev": true,
+            "requires": {
+                "unist-util-is": "3.0.0"
+            }
+        },
+        "unist-util-is": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-3.0.0.tgz",
+            "integrity": "sha512-sVZZX3+kspVNmLWBPAB6r+7D9ZgAFPNWm66f7YNb420RlQSbn+n8rG8dGZSkrER7ZIXGQYNm5pqC3v3HopH24A==",
+            "dev": true
+        },
+        "unist-util-remove-position": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-1.1.3.tgz",
+            "integrity": "sha512-CtszTlOjP2sBGYc2zcKA/CvNdTdEs3ozbiJ63IPBxh8iZg42SCCb8m04f8z2+V1aSk5a7BxbZKEdoDjadmBkWA==",
+            "dev": true,
+            "requires": {
+                "unist-util-visit": "1.4.1"
+            }
+        },
+        "unist-util-stringify-position": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-1.1.2.tgz",
+            "integrity": "sha512-pNCVrk64LZv1kElr0N1wPiHEUoXNVFERp+mlTg/s9R5Lwg87f9bM/3sQB99w+N9D/qnM9ar3+AKDBwo/gm/iQQ==",
+            "dev": true
+        },
+        "unist-util-visit": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.4.1.tgz",
+            "integrity": "sha512-AvGNk7Bb//EmJZyhtRUnNMEpId/AZ5Ph/KUpTI09WHQuDZHKovQ1oEv3mfmKpWKtoMzyMC4GLBm1Zy5k12fjIw==",
+            "dev": true,
+            "requires": {
+                "unist-util-visit-parents": "2.1.2"
+            }
+        },
+        "unist-util-visit-parents": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-2.1.2.tgz",
+            "integrity": "sha512-DyN5vD4NE3aSeB+PXYNKxzGsfocxp6asDc2XXE3b0ekO2BaRUpBicbbUygfSvYfUz1IkmjFR1YF7dPklraMZ2g==",
+            "dev": true,
+            "requires": {
+                "unist-util-is": "3.0.0"
+            }
+        },
+        "unpipe": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+            "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
+            "dev": true
+        },
+        "unquote": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/unquote/-/unquote-1.1.1.tgz",
+            "integrity": "sha1-j97XMk7G6IoP+LkF58CYzcCG1UQ=",
+            "dev": true
+        },
+        "unset-value": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
+            "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
+            "dev": true,
+            "requires": {
+                "has-value": "0.3.1",
+                "isobject": "3.0.1"
+            },
+            "dependencies": {
+                "has-value": {
+                    "version": "0.3.1",
+                    "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
+                    "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
+                    "dev": true,
+                    "requires": {
+                        "get-value": "2.0.6",
+                        "has-values": "0.1.4",
+                        "isobject": "2.1.0"
+                    },
+                    "dependencies": {
+                        "isobject": {
+                            "version": "2.1.0",
+                            "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+                            "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+                            "dev": true,
+                            "requires": {
+                                "isarray": "1.0.0"
+                            }
+                        }
+                    }
+                },
+                "has-values": {
+                    "version": "0.1.4",
+                    "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
+                    "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
+                    "dev": true
+                },
+                "isarray": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                    "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+                    "dev": true
+                }
+            }
+        },
+        "upath": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/upath/-/upath-1.1.2.tgz",
+            "integrity": "sha512-kXpym8nmDmlCBr7nKdIx8P2jNBa+pBpIUFRnKJ4dr8htyYGJFokkr2ZvERRtUN+9SY+JqXouNgUPtv6JQva/2Q==",
+            "dev": true
+        },
+        "upper-case": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.3.tgz",
+            "integrity": "sha1-9rRQHC7EzdJrp4vnIilh3ndiFZg=",
+            "dev": true
+        },
+        "uri-js": {
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
+            "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+            "dev": true,
+            "requires": {
+                "punycode": "2.1.1"
+            }
+        },
+        "urix": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
+            "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
+            "dev": true
+        },
+        "url": {
+            "version": "0.11.0",
+            "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
+            "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
+            "dev": true,
+            "requires": {
+                "punycode": "1.3.2",
+                "querystring": "0.2.0"
+            },
+            "dependencies": {
+                "punycode": {
+                    "version": "1.3.2",
+                    "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+                    "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
+                    "dev": true
+                }
+            }
+        },
+        "url-loader": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/url-loader/-/url-loader-2.1.0.tgz",
+            "integrity": "sha512-kVrp/8VfEm5fUt+fl2E0FQyrpmOYgMEkBsv8+UDP1wFhszECq5JyGF33I7cajlVY90zRZ6MyfgKXngLvHYZX8A==",
+            "dev": true,
+            "requires": {
+                "loader-utils": "1.2.3",
+                "mime": "2.4.4",
+                "schema-utils": "2.0.1"
+            },
+            "dependencies": {
+                "schema-utils": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.0.1.tgz",
+                    "integrity": "sha512-HJFKJ4JixDpRur06QHwi8uu2kZbng318ahWEKgBjc0ZklcE4FDvmm2wghb448q0IRaABxIESt8vqPFvwgMB80A==",
+                    "dev": true,
+                    "requires": {
+                        "ajv": "6.10.2",
+                        "ajv-keywords": "3.4.1"
+                    }
+                }
+            }
+        },
+        "url-parse": {
+            "version": "1.4.7",
+            "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.7.tgz",
+            "integrity": "sha512-d3uaVyzDB9tQoSXFvuSUNFibTd9zxd2bkVrDRvF5TmvWWQwqE4lgYJ5m+x1DbecWkw+LK4RNl2CU1hHuOKPVlg==",
+            "dev": true,
+            "requires": {
+                "querystringify": "2.1.1",
+                "requires-port": "1.0.0"
+            }
+        },
+        "use": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
+            "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
+            "dev": true
+        },
+        "util": {
+            "version": "0.11.1",
+            "resolved": "https://registry.npmjs.org/util/-/util-0.11.1.tgz",
+            "integrity": "sha512-HShAsny+zS2TZfaXxD9tYj4HQGlBezXZMZuM/S5PKLLoZkShZiGk9o5CzukI1LVHZvjdvZ2Sj1aW/Ndn2NB/HQ==",
+            "dev": true,
+            "requires": {
+                "inherits": "2.0.3"
+            },
+            "dependencies": {
+                "inherits": {
+                    "version": "2.0.3",
+                    "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                    "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+                    "dev": true
+                }
+            }
+        },
+        "util-deprecate": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+            "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+            "dev": true
+        },
+        "util.promisify": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.0.tgz",
+            "integrity": "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
+            "dev": true,
+            "requires": {
+                "define-properties": "1.1.3",
+                "object.getownpropertydescriptors": "2.0.3"
+            }
+        },
+        "utila": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/utila/-/utila-0.4.0.tgz",
+            "integrity": "sha1-ihagXURWV6Oupe7MWxKk+lN5dyw=",
+            "dev": true
+        },
+        "utils-merge": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+            "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
+            "dev": true
+        },
+        "uuid": {
+            "version": "3.3.2",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+            "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+            "dev": true
+        },
+        "v8-compile-cache": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.0.3.tgz",
+            "integrity": "sha512-CNmdbwQMBjwr9Gsmohvm0pbL954tJrNzf6gWL3K+QMQf00PF7ERGrEiLgjuU3mKreLC2MeGhUsNV9ybTbLgd3w==",
+            "dev": true
+        },
+        "validate-npm-package-license": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+            "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+            "dev": true,
+            "requires": {
+                "spdx-correct": "3.1.0",
+                "spdx-expression-parse": "3.0.0"
+            }
+        },
+        "value-equal": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/value-equal/-/value-equal-0.4.0.tgz",
+            "integrity": "sha512-x+cYdNnaA3CxvMaTX0INdTCN8m8aF2uY9BvEqmxuYp8bL09cs/kWVQPVGcA35fMktdOsP69IgU7wFj/61dJHEw=="
+        },
+        "vary": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+            "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
+            "dev": true
+        },
+        "vendors": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/vendors/-/vendors-1.0.3.tgz",
+            "integrity": "sha512-fOi47nsJP5Wqefa43kyWSg80qF+Q3XA6MUkgi7Hp1HQaKDQW4cQrK2D0P7mmbFtsV1N89am55Yru/nyEwRubcw==",
+            "dev": true
+        },
+        "vfile": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/vfile/-/vfile-3.0.1.tgz",
+            "integrity": "sha512-y7Y3gH9BsUSdD4KzHsuMaCzRjglXN0W2EcMf0gpvu6+SbsGhMje7xDc8AEoeXy6mIwCKMI6BkjMsRjzQbhMEjQ==",
+            "dev": true,
+            "requires": {
+                "is-buffer": "2.0.3",
+                "replace-ext": "1.0.0",
+                "unist-util-stringify-position": "1.1.2",
+                "vfile-message": "1.1.1"
+            },
+            "dependencies": {
+                "is-buffer": {
+                    "version": "2.0.3",
+                    "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.3.tgz",
+                    "integrity": "sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw==",
+                    "dev": true
+                }
+            }
+        },
+        "vfile-location": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-2.0.5.tgz",
+            "integrity": "sha512-Pa1ey0OzYBkLPxPZI3d9E+S4BmvfVwNAAXrrqGbwTVXWaX2p9kM1zZ+n35UtVM06shmWKH4RPRN8KI80qE3wNQ==",
+            "dev": true
+        },
+        "vfile-message": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-1.1.1.tgz",
+            "integrity": "sha512-1WmsopSGhWt5laNir+633LszXvZ+Z/lxveBf6yhGsqnQIhlhzooZae7zV6YVM1Sdkw68dtAW3ow0pOdPANugvA==",
+            "dev": true,
+            "requires": {
+                "unist-util-stringify-position": "1.1.2"
+            }
+        },
+        "vm-browserify": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.0.tgz",
+            "integrity": "sha512-iq+S7vZJE60yejDYM0ek6zg308+UZsdtPExWP9VZoCFCz1zkJoXFnAX7aZfd/ZwrkidzdUZL0C/ryW+JwAiIGw==",
+            "dev": true
+        },
+        "watchpack": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.6.0.tgz",
+            "integrity": "sha512-i6dHe3EyLjMmDlU1/bGQpEw25XSjkJULPuAVKCbNRefQVq48yXKUpwg538F7AZTf9kyr57zj++pQFltUa5H7yA==",
+            "dev": true,
+            "requires": {
+                "chokidar": "2.1.6",
+                "graceful-fs": "4.2.0",
+                "neo-async": "2.6.1"
+            }
+        },
+        "wbuf": {
+            "version": "1.7.3",
+            "resolved": "https://registry.npmjs.org/wbuf/-/wbuf-1.7.3.tgz",
+            "integrity": "sha512-O84QOnr0icsbFGLS0O3bI5FswxzRr8/gHwWkDlQFskhSPryQXvrTMxjxGP4+iWYoauLoBvfDpkrOauZ+0iZpDA==",
+            "dev": true,
+            "requires": {
+                "minimalistic-assert": "1.0.1"
+            }
+        },
+        "webpack": {
+            "version": "4.37.0",
+            "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.37.0.tgz",
+            "integrity": "sha512-iJPPvL7XpbcbwOthbzpa2BSPlmGp8lGDokAj/LdWtK80rsPoPOdANSbDBf2GAVLKZD3GhCuQ/gGkgN9HWs0Keg==",
+            "dev": true,
+            "requires": {
+                "@webassemblyjs/ast": "1.8.5",
+                "@webassemblyjs/helper-module-context": "1.8.5",
+                "@webassemblyjs/wasm-edit": "1.8.5",
+                "@webassemblyjs/wasm-parser": "1.8.5",
+                "acorn": "6.2.1",
+                "ajv": "6.10.2",
+                "ajv-keywords": "3.4.1",
+                "chrome-trace-event": "1.0.2",
+                "enhanced-resolve": "4.1.0",
+                "eslint-scope": "4.0.3",
+                "json-parse-better-errors": "1.0.2",
+                "loader-runner": "2.4.0",
+                "loader-utils": "1.2.3",
+                "memory-fs": "0.4.1",
+                "micromatch": "3.1.10",
+                "mkdirp": "0.5.1",
+                "neo-async": "2.6.1",
+                "node-libs-browser": "2.2.1",
+                "schema-utils": "1.0.0",
+                "tapable": "1.1.3",
+                "terser-webpack-plugin": "1.3.0",
+                "watchpack": "1.6.0",
+                "webpack-sources": "1.3.0"
+            },
+            "dependencies": {
+                "eslint-scope": {
+                    "version": "4.0.3",
+                    "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.3.tgz",
+                    "integrity": "sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==",
+                    "dev": true,
+                    "requires": {
+                        "esrecurse": "4.2.1",
+                        "estraverse": "4.2.0"
+                    }
+                }
+            }
+        },
+        "webpack-cli": {
+            "version": "3.3.6",
+            "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-3.3.6.tgz",
+            "integrity": "sha512-0vEa83M7kJtxK/jUhlpZ27WHIOndz5mghWL2O53kiDoA9DIxSKnfqB92LoqEn77cT4f3H2cZm1BMEat/6AZz3A==",
+            "dev": true,
+            "requires": {
+                "chalk": "2.4.2",
+                "cross-spawn": "6.0.5",
+                "enhanced-resolve": "4.1.0",
+                "findup-sync": "3.0.0",
+                "global-modules": "2.0.0",
+                "import-local": "2.0.0",
+                "interpret": "1.2.0",
+                "loader-utils": "1.2.3",
+                "supports-color": "6.1.0",
+                "v8-compile-cache": "2.0.3",
+                "yargs": "13.2.4"
+            },
+            "dependencies": {
+                "supports-color": {
+                    "version": "6.1.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+                    "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "3.0.0"
+                    }
+                }
+            }
+        },
+        "webpack-dev-middleware": {
+            "version": "3.7.0",
+            "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-3.7.0.tgz",
+            "integrity": "sha512-qvDesR1QZRIAZHOE3iQ4CXLZZSQ1lAUsSpnQmlB1PBfoN/xdRjmge3Dok0W4IdaVLJOGJy3sGI4sZHwjRU0PCA==",
+            "dev": true,
+            "requires": {
+                "memory-fs": "0.4.1",
+                "mime": "2.4.4",
+                "range-parser": "1.2.1",
+                "webpack-log": "2.0.0"
+            }
+        },
+        "webpack-dev-server": {
+            "version": "3.7.2",
+            "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.7.2.tgz",
+            "integrity": "sha512-mjWtrKJW2T9SsjJ4/dxDC2fkFVUw8jlpemDERqV0ZJIkjjjamR2AbQlr3oz+j4JLhYCHImHnXZK5H06P2wvUew==",
+            "dev": true,
+            "requires": {
+                "ansi-html": "0.0.7",
+                "bonjour": "3.5.0",
+                "chokidar": "2.1.6",
+                "compression": "1.7.4",
+                "connect-history-api-fallback": "1.6.0",
+                "debug": "4.1.1",
+                "del": "4.1.1",
+                "express": "4.17.1",
+                "html-entities": "1.2.1",
+                "http-proxy-middleware": "0.19.1",
+                "import-local": "2.0.0",
+                "internal-ip": "4.3.0",
+                "ip": "1.1.5",
+                "killable": "1.0.1",
+                "loglevel": "1.6.3",
+                "opn": "5.5.0",
+                "p-retry": "3.0.1",
+                "portfinder": "1.0.21",
+                "schema-utils": "1.0.0",
+                "selfsigned": "1.10.4",
+                "semver": "6.3.0",
+                "serve-index": "1.9.1",
+                "sockjs": "0.3.19",
+                "sockjs-client": "1.3.0",
+                "spdy": "4.0.0",
+                "strip-ansi": "3.0.1",
+                "supports-color": "6.1.0",
+                "url": "0.11.0",
+                "webpack-dev-middleware": "3.7.0",
+                "webpack-log": "2.0.0",
+                "yargs": "12.0.5"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+                    "dev": true
+                },
+                "cliui": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
+                    "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
+                    "dev": true,
+                    "requires": {
+                        "string-width": "2.1.1",
+                        "strip-ansi": "4.0.0",
+                        "wrap-ansi": "2.1.0"
+                    },
+                    "dependencies": {
+                        "strip-ansi": {
+                            "version": "4.0.0",
+                            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+                            "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+                            "dev": true,
+                            "requires": {
+                                "ansi-regex": "3.0.0"
+                            }
+                        }
+                    }
+                },
+                "get-caller-file": {
+                    "version": "1.0.3",
+                    "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
+                    "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
+                    "dev": true
+                },
+                "is-fullwidth-code-point": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+                    "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+                    "dev": true,
+                    "requires": {
+                        "number-is-nan": "1.0.1"
+                    }
+                },
+                "require-main-filename": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+                    "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+                    "dev": true
+                },
+                "semver": {
+                    "version": "6.3.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "6.1.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+                    "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "3.0.0"
+                    }
+                },
+                "wrap-ansi": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+                    "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+                    "dev": true,
+                    "requires": {
+                        "string-width": "1.0.2",
+                        "strip-ansi": "3.0.1"
+                    },
+                    "dependencies": {
+                        "string-width": {
+                            "version": "1.0.2",
+                            "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+                            "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+                            "dev": true,
+                            "requires": {
+                                "code-point-at": "1.1.0",
+                                "is-fullwidth-code-point": "1.0.0",
+                                "strip-ansi": "3.0.1"
+                            }
+                        }
+                    }
+                },
+                "yargs": {
+                    "version": "12.0.5",
+                    "resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
+                    "integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
+                    "dev": true,
+                    "requires": {
+                        "cliui": "4.1.0",
+                        "decamelize": "1.2.0",
+                        "find-up": "3.0.0",
+                        "get-caller-file": "1.0.3",
+                        "os-locale": "3.1.0",
+                        "require-directory": "2.1.1",
+                        "require-main-filename": "1.0.1",
+                        "set-blocking": "2.0.0",
+                        "string-width": "2.1.1",
+                        "which-module": "2.0.0",
+                        "y18n": "4.0.0",
+                        "yargs-parser": "11.1.1"
+                    }
+                },
+                "yargs-parser": {
+                    "version": "11.1.1",
+                    "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
+                    "integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
+                    "dev": true,
+                    "requires": {
+                        "camelcase": "5.3.1",
+                        "decamelize": "1.2.0"
+                    }
+                }
+            }
+        },
+        "webpack-log": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/webpack-log/-/webpack-log-2.0.0.tgz",
+            "integrity": "sha512-cX8G2vR/85UYG59FgkoMamwHUIkSSlV3bBMRsbxVXVUk2j6NleCKjQ/WE9eYg9WY4w25O9w8wKP4rzNZFmUcUg==",
+            "dev": true,
+            "requires": {
+                "ansi-colors": "3.2.4",
+                "uuid": "3.3.2"
+            }
+        },
+        "webpack-merge": {
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-4.2.1.tgz",
+            "integrity": "sha512-4p8WQyS98bUJcCvFMbdGZyZmsKuWjWVnVHnAS3FFg0HDaRVrPbkivx2RYCre8UiemD67RsiFFLfn4JhLAin8Vw==",
+            "dev": true,
+            "requires": {
+                "lodash": "4.17.15"
+            }
+        },
+        "webpack-sources": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.3.0.tgz",
+            "integrity": "sha512-OiVgSrbGu7NEnEvQJJgdSFPl2qWKkWq5lHMhgiToIiN9w34EBnjYzSYs+VbL5KoYiLNtFFa7BZIKxRED3I32pA==",
+            "dev": true,
+            "requires": {
+                "source-list-map": "2.0.1",
+                "source-map": "0.6.1"
+            },
+            "dependencies": {
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
+                }
+            }
+        },
+        "websocket-driver": {
+            "version": "0.7.3",
+            "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.3.tgz",
+            "integrity": "sha512-bpxWlvbbB459Mlipc5GBzzZwhoZgGEZLuqPaR0INBGnPAY1vdBX6hPnoFXiw+3yWxDuHyQjO2oXTMyS8A5haFg==",
+            "dev": true,
+            "requires": {
+                "http-parser-js": "0.4.10",
+                "safe-buffer": "5.1.2",
+                "websocket-extensions": "0.1.3"
+            }
+        },
+        "websocket-extensions": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.3.tgz",
+            "integrity": "sha512-nqHUnMXmBzT0w570r2JpJxfiSD1IzoI+HGVdd3aZ0yNi3ngvQ4jv1dtHt5VGxfI2yj5yqImPhOK4vmIh2xMbGg==",
+            "dev": true
+        },
+        "which": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+            "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+            "dev": true,
+            "requires": {
+                "isexe": "2.0.0"
+            }
+        },
+        "which-module": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+            "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+            "dev": true
+        },
+        "wordwrap": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+            "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+            "dev": true
+        },
+        "worker-farm": {
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.7.0.tgz",
+            "integrity": "sha512-rvw3QTZc8lAxyVrqcSGVm5yP/IJ2UcB3U0graE3LCFoZ0Yn2x4EoVSqJKdB/T5M+FLcRPjz4TDacRf3OCfNUzw==",
+            "dev": true,
+            "requires": {
+                "errno": "0.1.7"
+            }
+        },
+        "wrap-ansi": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+            "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+            "dev": true,
+            "requires": {
+                "ansi-styles": "3.2.1",
+                "string-width": "3.1.0",
+                "strip-ansi": "5.2.0"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+                    "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+                    "dev": true
+                },
+                "string-width": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+                    "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+                    "dev": true,
+                    "requires": {
+                        "emoji-regex": "7.0.3",
+                        "is-fullwidth-code-point": "2.0.0",
+                        "strip-ansi": "5.2.0"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+                    "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "4.1.0"
+                    }
+                }
+            }
+        },
+        "wrappy": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+            "dev": true
+        },
+        "write": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/write/-/write-1.0.3.tgz",
+            "integrity": "sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==",
+            "dev": true,
+            "requires": {
+                "mkdirp": "0.5.1"
+            }
+        },
+        "x-is-string": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/x-is-string/-/x-is-string-0.1.0.tgz",
+            "integrity": "sha1-R0tQhlrzpJqcRlfwWs0UVFj3fYI=",
+            "dev": true
+        },
+        "xtend": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+            "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+            "dev": true
+        },
+        "y18n": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+            "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+            "dev": true
+        },
+        "yallist": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+            "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
+            "dev": true
+        },
+        "yargs": {
+            "version": "13.2.4",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.2.4.tgz",
+            "integrity": "sha512-HG/DWAJa1PAnHT9JAhNa8AbAv3FPaiLzioSjCcmuXXhP8MlpHO5vwls4g4j6n30Z74GVQj8Xa62dWVx1QCGklg==",
+            "dev": true,
+            "requires": {
+                "cliui": "5.0.0",
+                "find-up": "3.0.0",
+                "get-caller-file": "2.0.5",
+                "os-locale": "3.1.0",
+                "require-directory": "2.1.1",
+                "require-main-filename": "2.0.0",
+                "set-blocking": "2.0.0",
+                "string-width": "3.1.0",
+                "which-module": "2.0.0",
+                "y18n": "4.0.0",
+                "yargs-parser": "13.1.1"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+                    "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+                    "dev": true
+                },
+                "string-width": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+                    "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+                    "dev": true,
+                    "requires": {
+                        "emoji-regex": "7.0.3",
+                        "is-fullwidth-code-point": "2.0.0",
+                        "strip-ansi": "5.2.0"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+                    "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "4.1.0"
+                    }
+                },
+                "yargs-parser": {
+                    "version": "13.1.1",
+                    "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.1.tgz",
+                    "integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
+                    "dev": true,
+                    "requires": {
+                        "camelcase": "5.3.1",
+                        "decamelize": "1.2.0"
+                    }
+                }
+            }
+        },
+        "yargs-parser": {
+            "version": "10.1.0",
+            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.1.0.tgz",
+            "integrity": "sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==",
+            "dev": true,
+            "requires": {
+                "camelcase": "4.1.0"
+            },
+            "dependencies": {
+                "camelcase": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+                    "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+                    "dev": true
+                }
+            }
+        }
+    }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "starbase-react",
-    "version": "2.0.0",
+    "version": "2.1.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "starbase-react",
-    "version": "2.0.0",
+    "version": "2.1.0",
     "author": "Brian Staruk <brian@staruk.net>",
     "contributors": [
         {

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
     "name": "starbase-react",
     "version": "2.0.0",
-    "author": "Brian Staruk <brian@staruk.me>",
+    "author": "Brian Staruk <brian@staruk.net>",
     "contributors": [
         {
             "name": "Brian Staruk",
-            "email": "brian@staruk.me",
-            "url": "https://brian.staruk.me"
+            "email": "brian@staruk.net",
+            "url": "https://brian.staruk.net"
         }
     ],
     "description": "an offline-first React 16 boilerplate w/ webpack 4, PostCSS, Babel 7 (ES6+) & more",
@@ -17,7 +17,7 @@
     },
     "bugs": {
         "url": "https://github.com/bstaruk/starbase-react/issues",
-        "email": "brian@staruk.me"
+        "email": "brian@staruk.net"
     },
     "engines": {
         "node": ">=8.9"
@@ -36,20 +36,20 @@
         "babel-eslint": "^10.0.1",
         "babel-loader": "^8.0.5",
         "babel-plugin-transform-class-properties": "^6.24.1",
-        "clean-webpack-plugin": "^1.0.1",
-        "css-loader": "^2.1.0",
+        "clean-webpack-plugin": "^3.0.0",
+        "css-loader": "^3.1.0",
         "css-mqpacker": "^7.0.0",
         "cssnano": "^4.1.8",
-        "eslint": "^5.13.0",
+        "eslint": "^6.1.0",
         "eslint-config-airbnb": "^17.1.0",
         "eslint-loader": "^2.1.2",
         "eslint-plugin-import": "^2.16.0",
         "eslint-plugin-jsx-a11y": "^6.2.1",
         "eslint-plugin-react": "^7.12.4",
-        "file-loader": "^3.0.1",
+        "file-loader": "^4.1.0",
         "html-loader": "^0.5.5",
         "html-webpack-plugin": "^3.2.0",
-        "mini-css-extract-plugin": "^0.5.0",
+        "mini-css-extract-plugin": "^0.8.0",
         "offline-plugin": "^5.0.6",
         "postcss": "^7.0.14",
         "postcss-extend": "^1.0.5",
@@ -60,9 +60,9 @@
         "postcss-remove-root": "0.0.2",
         "postcss-reporter": "^6.0.1",
         "style-loader": "^0.23.1",
-        "stylelint": "^9.10.1",
+        "stylelint": "^10.1.0",
         "stylelint-config-standard": "^18.2.0",
-        "url-loader": "^1.1.2",
+        "url-loader": "^2.1.0",
         "webpack": "^4.29.3",
         "webpack-cli": "^3.2.3",
         "webpack-dev-server": "^3.1.14",
@@ -73,6 +73,6 @@
         "react": "^16.8.1",
         "react-dom": "^16.8.1",
         "react-hot-loader": "^4.6.5",
-        "react-router-dom": "^4.3.1"
+        "react-router-dom": "^5.0.1"
     }
 }

--- a/src/components/Footer/Footer.css
+++ b/src/components/Footer/Footer.css
@@ -2,8 +2,8 @@
 
 .footer {
   margin-top: 2.5rem;
-  border-top: 1px solid #ccc;
-  color: #888;
+  border-top: 1px solid var(--color-silver);
+  color: var(--color-gray);
 
   @media (--medium) {
     font-size: 0.9em;

--- a/src/components/Footer/Footer.jsx
+++ b/src/components/Footer/Footer.jsx
@@ -1,9 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-const Footer = ({
-  children
-}) => (
+const Footer = ({ children }) => (
   <footer role="contentinfo" className="footer">
     {children}
   </footer>

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -4,47 +4,43 @@ import HeaderLink from './HeaderLink.jsx';
 
 import logo from './assets/starbase.png';
 
-class Header extends React.PureComponent {
-  render() {
-    return (
-      <header role="banner" className="header">
-        <div className="header__brand">
-          <img src={logo} alt="starbase logo" className="header__image" />
-          <h1 className="header__title">{this.props.title}</h1>
-        </div>
-        <p>starbase-react is an open source webpack 4, React 16 &amp; PostCSS boilerplate for web developers, with a small footprint and plenty of room for cream and sugar-- make it your own!</p>
+const Header = ({ title }) => (
+  <header role="banner" className="header">
+    <div className="header__brand">
+      <img src={logo} alt="starbase logo" className="header__image" />
+      <h1 className="header__title">{title}</h1>
+    </div>
+    <p>starbase-react is an open source webpack 4, React 16 &amp; PostCSS boilerplate for web developers, with a small footprint and plenty of room for cream and sugar-- make it your own!</p>
 
-        <nav>
-          <ul role="tablist" className="header__nav">
-            <li>
-              <HeaderLink
-                linkTo="/"
-                title="a brief history of starbase-react-- it's got electrolytes!"
-                label="Why it's here"
-              />
-            </li>
+    <nav>
+      <ul role="tablist" className="header__nav">
+        <li>
+          <HeaderLink
+            linkTo="/"
+            title="a brief history of starbase-react-- it's got electrolytes!"
+            label="Why it's here"
+          />
+        </li>
 
-            <li>
-              <HeaderLink
-                linkTo="/what"
-                title="an overview of the starbase-react commands"
-                label="What it does"
-              />
-            </li>
+        <li>
+          <HeaderLink
+            linkTo="/what"
+            title="an overview of the starbase-react commands"
+            label="What it does"
+          />
+        </li>
 
-            <li>
-              <HeaderLink
-                linkTo="/who"
-                title="free software is for you and me"
-                label="Who it's for"
-              />
-            </li>
-          </ul>
-        </nav>
-      </header>
-    );
-  }
-}
+        <li>
+          <HeaderLink
+            linkTo="/who"
+            title="free software is for you and me"
+            label="Who it's for"
+          />
+        </li>
+      </ul>
+    </nav>
+  </header>
+);
 
 Header.propTypes = {
   title: PropTypes.string.isRequired

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -4,20 +4,7 @@ import HeaderLink from './HeaderLink.jsx';
 
 import logo from './assets/starbase.png';
 
-class Header extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      activeTab: window.location.pathname || '/'
-    };
-  }
-
-  setActiveTab = (activeTab) => {
-    this.setState({
-      activeTab
-    });
-  };
-
+class Header extends React.PureComponent {
   render() {
     return (
       <header role="banner" className="header">
@@ -31,8 +18,6 @@ class Header extends React.Component {
           <ul role="tablist" className="header__nav">
             <li>
               <HeaderLink
-                handleClick={this.setActiveTab}
-                isActive={this.state.activeTab === '/'}
                 linkTo="/"
                 title="a brief history of starbase-react-- it's got electrolytes!"
                 label="Why it's here"
@@ -41,8 +26,6 @@ class Header extends React.Component {
 
             <li>
               <HeaderLink
-                handleClick={this.setActiveTab}
-                isActive={this.state.activeTab === '/what'}
                 linkTo="/what"
                 title="an overview of the starbase-react commands"
                 label="What it does"
@@ -51,8 +34,6 @@ class Header extends React.Component {
 
             <li>
               <HeaderLink
-                handleClick={this.setActiveTab}
-                isActive={this.state.activeTab === '/who'}
                 linkTo="/who"
                 title="free software is for you and me"
                 label="Who it's for"
@@ -68,6 +49,5 @@ class Header extends React.Component {
 Header.propTypes = {
   title: PropTypes.string.isRequired
 };
-
 
 export default Header;

--- a/src/components/Header/HeaderLink.jsx
+++ b/src/components/Header/HeaderLink.jsx
@@ -2,20 +2,16 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { NavLink } from 'react-router-dom';
 
-class HeaderLink extends React.PureComponent {
-  render() {
-    return (
-      <NavLink
-        exact
-        to={this.props.linkTo}
-        title={this.props.title}
-        activeClassName="header__link header__link--active"
-      >
-        {this.props.label}
-      </NavLink>
-    );
-  }
-}
+const HeaderLink = ({ label, linkTo, title }) => (
+  <NavLink
+    exact
+    to={linkTo}
+    title={title}
+    activeClassName="header__link header__link--active"
+  >
+    {label}
+  </NavLink>
+);
 
 HeaderLink.propTypes = {
   title: PropTypes.string.isRequired,

--- a/src/components/Header/HeaderLink.jsx
+++ b/src/components/Header/HeaderLink.jsx
@@ -1,27 +1,23 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Link } from 'react-router-dom';
+import { NavLink } from 'react-router-dom';
 
-class HeaderLink extends React.Component {
-  handleClick = () => this.props.handleClick(this.props.linkTo);
-
+class HeaderLink extends React.PureComponent {
   render() {
     return (
-      <Link
+      <NavLink
+        exact
         to={this.props.linkTo}
         title={this.props.title}
-        className={this.props.isActive ? 'header__link header__link--active' : 'header__link'}
-        onClick={this.handleClick}
+        activeClassName="header__link header__link--active"
       >
         {this.props.label}
-      </Link>
+      </NavLink>
     );
   }
 }
 
 HeaderLink.propTypes = {
-  isActive: PropTypes.bool.isRequired,
-  handleClick: PropTypes.func.isRequired,
   title: PropTypes.string.isRequired,
   label: PropTypes.string.isRequired,
   linkTo: PropTypes.string.isRequired

--- a/src/components/Main/Main.css
+++ b/src/components/Main/Main.css
@@ -13,14 +13,15 @@ body {
   max-width: var(--body-width-max);
   background-color: var(--color-white);
   font-family: var(--font-sans);
-  font-size: 0.95em;
+  font-size: 0.95rem;
+  font-weight: 400;
   line-height: 1.4;
   color: var(--color-mine-shaft);
   padding: 1rem;
   margin: 0 auto;
 
   @media (--medium) {
-    font-size: 1.05em;
+    font-size: 1rem;
     padding-top: 2rem;
   }
 }

--- a/src/components/Main/Main.css
+++ b/src/components/Main/Main.css
@@ -11,11 +11,11 @@
 
 body {
   max-width: var(--body-width-max);
-  background-color: var(--body-bg-color);
+  background-color: var(--color-white);
   font-family: var(--font-sans);
   font-size: 0.95em;
   line-height: 1.4;
-  color: var(--body-font-color);
+  color: var(--color-mine-shaft);
   padding: 1rem;
   margin: 0 auto;
 
@@ -26,10 +26,10 @@ body {
 }
 
 a {
-  color: var(--anchor-font-color);
+  color: var(--color-mariner);
   transition: color 200ms ease;
 
   &:hover {
-    color: var(--anchor-hover-font-color);
+    color: var(--color-picton-blue);
   }
 }

--- a/src/components/Main/Main.jsx
+++ b/src/components/Main/Main.jsx
@@ -21,7 +21,7 @@ const Main = () => (
     </Switch>
 
     <Footer>
-      <p>crafted in boston by <a href="https://brian.staruk.me" title="continue to brian.staruk.me" className="h-card">brian staruk</a> | <a href="https://github.com/bstaruk/starbase-react" title="learn more about starbase-react on github">starbase-react on github</a></p>
+      <p>crafted in boston by <a href="https://brian.staruk.net" title="continue to brian.staruk.net" className="h-card">brian staruk</a> | <a href="https://github.com/bstaruk/starbase-react" title="learn more about starbase-react on github">starbase-react on github</a></p>
     </Footer>
   </main>
 );

--- a/src/components/RichText/RichText.jsx
+++ b/src/components/RichText/RichText.jsx
@@ -1,9 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-const RichText = ({
-  children
-}) => (
+const RichText = ({ children }) => (
   <div className="rich-text">
     {children}
   </div>

--- a/src/variables/variables.css
+++ b/src/variables/variables.css
@@ -1,9 +1,11 @@
 :root {
   /* theme colors */
-  --body-bg-color: #fefefe;
-  --body-font-color: #333;
-  --anchor-font-color: #2472be;
-  --anchor-hover-font-color: #23a5f0;
+  --color-white: #fefefe;
+  --color-silver: #ccc;
+  --color-gray: #888;
+  --color-mine-shaft: #333;
+  --color-mariner: #2472be;
+  --color-picton-blue: #23a5f0;
 
   /* typography */
   --font-sans: 'PT Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;

--- a/webpack/webpack.config.prod.js
+++ b/webpack/webpack.config.prod.js
@@ -1,7 +1,6 @@
-const CleanWebpackPlugin = require('clean-webpack-plugin');
+const { CleanWebpackPlugin } = require('clean-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const OfflinePlugin = require('offline-plugin');
-const path = require('path');
 const webpackMerge = require('webpack-merge');
 
 // postcss plugins
@@ -70,11 +69,7 @@ module.exports = webpackMerge(webpackConfigBase, {
       filename: '[name].[hash:8].css',
       chunkFilename: '[id].[hash:8].css'
     }),
-    new CleanWebpackPlugin([
-      'dist'
-    ], {
-      root: path.resolve(__dirname, '../')
-    }),
+    new CleanWebpackPlugin(),
     new OfflinePlugin({
       AppCache: false
     })


### PR DESCRIPTION
`2.1.0` is a maintenance release that aims to keep the react variant inline with [vanilla starbase](https://github.com/bstaruk/starbase). It also contains some light JSX cleanup.

This is a minor, instead of an incremental update because a change was required to the production webpack config for a dependency update. If that wasn't necessary, this would have been the `2.0.1` release.

### Patch notes:

* All dependencies updated.
  * Tweaks to production webpack config was necessary for `clean-webpack-plugin` major update.
* JSX cleaned up.
  * A couple `React.Component`s replaced with functions.
  * Ditched a stateful `Header` component, for `react-router-dom`'s `NavLink` & `activeClassName`
* CSS color variables tweaked to be slightly less-terrible than they were before.