### PR TITLE
4.1.0

### DIFF
--- a/internals/webpack/webpack.config.dev.js
+++ b/internals/webpack/webpack.config.dev.js
@@ -9,7 +9,7 @@ module.exports = merge(webpackConfigBase, {
   output: {
     filename: '[name].js',
   },
-  devtool: 'inline-source-map',
+  devtool: 'eval-source-map',
   devServer: {
     contentBase: path.join(process.cwd(), 'dist'),
     historyApiFallback: true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -4555,6 +4555,14 @@
       "integrity": "sha512-e54B99q/OUoH64zYYRf3HBP5z24G38h5D3qXu23JGRoigpX5Ss4r9ZnDk3g0Z8uQC2x2lPaJ+UlWBc1ZWBWdLg==",
       "dev": true
     },
+    "connected-react-router": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/connected-react-router/-/connected-react-router-6.8.0.tgz",
+      "integrity": "sha512-E64/6krdJM3Ag3MMmh2nKPtMbH15s3JQDuaYJvOVXzu6MbHbDyIvuwLOyhQIuP4Om9zqEfZYiVyflROibSsONg==",
+      "requires": {
+        "prop-types": "^15.7.2"
+      }
+    },
     "console-browserify": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.2.0.tgz",
@@ -13136,6 +13144,21 @@
         "react-is": "^16.6.0",
         "tiny-invariant": "^1.0.2",
         "tiny-warning": "^1.0.0"
+      },
+      "dependencies": {
+        "history": {
+          "version": "4.10.1",
+          "resolved": "https://registry.npmjs.org/history/-/history-4.10.1.tgz",
+          "integrity": "sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==",
+          "requires": {
+            "@babel/runtime": "^7.1.2",
+            "loose-envify": "^1.2.0",
+            "resolve-pathname": "^3.0.0",
+            "tiny-invariant": "^1.0.2",
+            "tiny-warning": "^1.0.0",
+            "value-equal": "^1.0.1"
+          }
+        }
       }
     },
     "react-router-dom": {
@@ -13150,6 +13173,21 @@
         "react-router": "5.2.0",
         "tiny-invariant": "^1.0.2",
         "tiny-warning": "^1.0.0"
+      },
+      "dependencies": {
+        "history": {
+          "version": "4.10.1",
+          "resolved": "https://registry.npmjs.org/history/-/history-4.10.1.tgz",
+          "integrity": "sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==",
+          "requires": {
+            "@babel/runtime": "^7.1.2",
+            "loose-envify": "^1.2.0",
+            "resolve-pathname": "^3.0.0",
+            "tiny-invariant": "^1.0.2",
+            "tiny-warning": "^1.0.0",
+            "value-equal": "^1.0.1"
+          }
+        }
       }
     },
     "react-side-effect": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "starbase-react",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -75,6 +75,8 @@
     "webpack-merge": "^5.1.1"
   },
   "dependencies": {
+    "connected-react-router": "^6.8.0",
+    "history": "^4.10.1",
     "immer": "^7.0.7",
     "prop-types": "^15.7.2",
     "react": "^16.13.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "starbase-react",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "author": "Brian Staruk <brian@staruk.net>",
   "contributors": [
     {

--- a/src/app.js
+++ b/src/app.js
@@ -2,20 +2,21 @@ import '@babel/polyfill'; // keep at top for redux-saga generator support
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
-import { BrowserRouter } from 'react-router-dom';
+import { ConnectedRouter } from 'connected-react-router';
 import * as OfflinePluginRuntime from 'offline-plugin/runtime';
 
 import App from 'containers/App';
+import history from 'utils/history';
 
 import configureStore from './store';
 
-const store = configureStore();
+const store = configureStore(history);
 
 ReactDOM.render(
   <Provider store={store}>
-    <BrowserRouter>
+    <ConnectedRouter history={history}>
       <App />
-    </BrowserRouter>
+    </ConnectedRouter>
   </Provider>,
   document.getElementById('root'),
 );

--- a/src/store.js
+++ b/src/store.js
@@ -1,5 +1,7 @@
 import { combineReducers, createStore, applyMiddleware, compose } from 'redux';
+import { connectRouter, routerMiddleware } from 'connected-react-router';
 import createSagaMiddleware from 'redux-saga';
+import history from 'utils/history';
 
 // import reducers (ctrl+f "SETUP REDUCERS")
 import statsPageReducer from 'containers/StatsPage/reducer';
@@ -10,6 +12,7 @@ import getStatsPageSaga from 'containers/StatsPage/saga';
 function createReducer(injectedReducers = {}) {
   // SETUP REDUCERS HERE
   const rootReducer = combineReducers({
+    router: connectRouter(history),
     statsPage: statsPageReducer,
     ...injectedReducers,
   });
@@ -18,7 +21,7 @@ function createReducer(injectedReducers = {}) {
 }
 
 // main redux config function that's passed back to app.js
-export default function configureStore() {
+export default function configureStore(routerHistory) {
   let composeEnhancers = compose;
   const reduxSagaMonitorOptions = {};
 
@@ -32,7 +35,7 @@ export default function configureStore() {
   const sagaMiddleware = createSagaMiddleware(reduxSagaMonitorOptions);
 
   // create middlewares array & apply them
-  const middlewares = [sagaMiddleware];
+  const middlewares = [sagaMiddleware, routerMiddleware(routerHistory)];
   const enhancers = [applyMiddleware(...middlewares)];
 
   // it's alive!

--- a/src/utils/history.js
+++ b/src/utils/history.js
@@ -1,0 +1,3 @@
+import { createBrowserHistory } from 'history';
+
+export default createBrowserHistory();


### PR DESCRIPTION
This is a minor release that:

* switches from BrowserHistory to ConnectedHistory -- this stores our react-router history state in redux.
* switches dev sourcemaps from line to eval -- this should speed up the build slightly and there is essentially no difference in dev flow.